### PR TITLE
Chore: site health CI, templates, Actions v6, maintenance reminder

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-pages-blank-content.yml
+++ b/.github/ISSUE_TEMPLATE/bug-pages-blank-content.yml
@@ -1,5 +1,5 @@
-name: "[BUG] GitHub Pages shows no content"
-description: "The live site loads but the React content is missing/blank."
+name: '[BUG] GitHub Pages blank or missing React'
+description: Specialized — site loads but the React shell shows no usable content. Prefer **Something is wrong** for other bugs.
 title: "[BUG]: GitHub Pages loads but shows no content"
 labels:
   - bug

--- a/.github/ISSUE_TEMPLATE/bug-pages-blank-content.yml
+++ b/.github/ISSUE_TEMPLATE/bug-pages-blank-content.yml
@@ -1,5 +1,7 @@
 name: '[BUG] GitHub Pages blank or missing React'
-description: Specialized — site loads but the React shell shows no usable content. Prefer **Something is wrong** for other bugs.
+description: >-
+  Specialized — GitHub Pages loads but React content is blank or incomplete.
+  Prefer the generic “Something is wrong” bug template for unrelated defects.
 title: "[BUG]: GitHub Pages loads but shows no content"
 labels:
   - bug

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,52 @@
+name: '[BUG] Something is wrong'
+description: Report a defect (generic). Use specialized templates if your case matches them.
+title: '[BUG]: '
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem clearly. If the site loads but React content is blank, use **“GitHub Pages blank or missing content”** instead.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One short sentence on what is broken.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps so someone else can see the same behaviour.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+    validations:
+      required: true
+
+  - type: input
+    id: scope
+    attributes:
+      label: Environment / context (browser, CI, localhost, …)
+      placeholder: Chrome 139, localhost; or GitHub Actions run URL
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes (errors, screenshots, suspects)
+      description: Optional.

--- a/.github/ISSUE_TEMPLATE/chore-periodic-maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/chore-periodic-maintenance.yml
@@ -1,0 +1,57 @@
+name: '[CHORE] Periodic maintenance review'
+description: Quarterly (or manual) upkeep — CI, tooling, audits, Pages health.
+title: '[CHORE]: Periodic maintenance '
+labels:
+  - chore
+  - maintenance
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use **after** the scheduled quarterly reminder opens an issue **or** when you voluntarily run hygiene. Tick items that apply.
+
+  - type: checkboxes
+    id: workflows
+    attributes:
+      label: GitHub Actions
+      options:
+        - label: Review pin versions (actions/checkout, actions/setup-node, deploy-pages, …) against release notes / Node rollout
+          required: false
+        - label: Re-check FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 workflow env — remove once defaults match deploy.yml checklist
+          required: false
+        - label: Confirm Site health (GitHub Pages) workflow last run is green on main
+          required: false
+        - label: Confirm Security audit weekly workflow still meets policy
+          required: false
+
+  - type: checkboxes
+    id: deps
+    attributes:
+      label: Dependencies and supply chain
+      options:
+        - label: npm audit locally with same policy as CI (moderate+) and address new findings
+          required: false
+        - label: Review Dependabot PRs — merge or postpone with reason
+          required: false
+
+  - type: checkboxes
+    id: app
+    attributes:
+      label: Live site sanity
+      options:
+        - label: Smoke key routes (Home, Profile, Projects, Opportunity Evaluator) on production URL after last deploy
+          required: false
+
+  - type: checkboxes
+    id: extra
+    attributes:
+      label: Tooling (if present in repo)
+      options:
+        - label: pre-commit hooks refreshed (autoupdate) — skip if repo has no pre-commit
+          required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes / follow-ups
+      description: PR links, bumped versions, postponed items.

--- a/.github/ISSUE_TEMPLATE/chore-request.yml
+++ b/.github/ISSUE_TEMPLATE/chore-request.yml
@@ -1,0 +1,25 @@
+name: '[CHORE] Maintenance or hygiene'
+description: Refactors, dependency bumps, tooling, CI, docs housekeeping — behaviour unchanged for users unless noted.
+title: '[CHORE]: '
+labels:
+  - chore
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: The change — keep it small and reversible when possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: risk
+    attributes:
+      label: Impact / risk
+      placeholder: e.g. bumps deploy.yml only; npm audit clean
+
+  - type: textarea
+    id: verify
+    attributes:
+      label: Verification
+      placeholder: Commands or checks — npm test, workflows green, ...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,34 @@
+name: '[FEAT] New feature'
+description: Propose a new capability or user-visible behaviour.
+title: '[FEAT]: '
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / opportunity
+      description: What user or maintenance pain does this address?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What should happen instead? Keep scope clear.
+    validations:
+      required: true
+
+  - type: textarea
+    id: ac
+    attributes:
+      label: Suggested acceptance criteria
+      placeholder: |-
+        - [ ] Behaviour X works when ...
+        - [ ] Regression tests ...
+
+  - type: textarea
+    id: out
+    attributes:
+      label: Out of scope (optional)

--- a/.github/ISSUE_TEMPLATE/task-tracked.yml
+++ b/.github/ISSUE_TEMPLATE/task-tracked.yml
@@ -1,0 +1,26 @@
+name: '[TASK] Tracked piece of work'
+description: Planned work item (engineering or ops) — not urgent defect, not necessarily a net-new feature.
+title: '[TASK]: '
+labels:
+  - task
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What needs to happen and why now?
+    validations:
+      required: true
+
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of done
+      placeholder: |-
+        - [ ] ...
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links / context
+      placeholder: Related issue PR, docs, ...

--- a/.github/scripts/render-maintenance-issue-body.sh
+++ b/.github/scripts/render-maintenance-issue-body.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Emit issue body copied from tracked template (.github/templates/maintenance-issue-body.md).
+
+set -euo pipefail
+ROOT="$(dirname "$0")/../.."
+TEMPLATE="${ROOT}/.github/templates/maintenance-issue-body.md"
+if [[ ! -f "${TEMPLATE}" ]]; then
+  echo "missing ${TEMPLATE}"
+  exit 1
+fi
+cat "${TEMPLATE}"

--- a/.github/templates/maintenance-issue-body.md
+++ b/.github/templates/maintenance-issue-body.md
@@ -1,0 +1,16 @@
+## Periodic maintenance checklist
+
+This issue was opened by the **Periodic maintenance reminder** workflow. Work items below track routine upkeep for this Pages site repo.
+
+References:
+
+- [Site health (GitHub Pages) workflow — Actions](https://github.com/pkuppens/pkuppens.github.io/actions/workflows/site-health.yml)
+
+- [Deploy workflow — Actions](https://github.com/pkuppens/pkuppens.github.io/actions/workflows/deploy.yml)
+
+- Use the **`[CHORE] Periodic maintenance review`** issue template for the checklist when converting work into actionable items.
+
+---
+
+When finished, close this issue after a short recap (what you merged, bumped, or deferred).
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@
 # (expected >= 2026-06-02). Preconditions before removing:
 #   1. Date >= 2026-06-02 (forced Node 24 default date per GitHub changelog).
 #   2. ubuntu-latest runner images no longer warn about Node.js 20 deprecation.
-#   3. actions/checkout@v4 (or newer) ships a Node 24 runtime (verify release notes).
-#   4. actions/setup-node@v4 (or newer) ships a Node 24 runtime (verify release notes).
+#   3. actions/checkout@v6 (or newer) ships a Node 24 runtime for the shim (verify release notes).
+#   4. actions/setup-node@v6 (or newer) ships a Node 24 runtime for the shim (verify release notes).
 #   5. A workflow_dispatch run WITHOUT FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 produces no Node 20 warning.
 # See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
 name: Deploy to GitHub Pages
@@ -31,10 +31,10 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/maintenance-reminder.yml
+++ b/.github/workflows/maintenance-reminder.yml
@@ -1,0 +1,88 @@
+# Opens a housekeeping issue Feb/May/Aug/Nov — first Saturday, ~local 05:30 Europe/Amsterdam.
+# Cron is UTC-only; gate uses Europe/Amsterdam and a narrow local time band.
+#
+# Same FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 stance as deploy.yml until upstream actions drop Node20 shims.
+# See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+name: Periodic maintenance reminder
+
+on:
+  schedule:
+    # Every Saturday UTC — narrowed in `slot` to quarterly Amsterdam window.
+    - cron: '30 4 * * 6'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: periodic-maintenance
+  cancel-in-progress: false
+
+jobs:
+  reminder:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - name: Decide whether today is maintenance slot (quarterly + Amsterdam Saturday + morning window)
+        id: slot
+        env:
+          TRIGGER_EVENT: ${{ github.event_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${TRIGGER_EVENT}" == 'workflow_dispatch' ]]; then
+            echo 'should_run=true' >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          MONTH=$((10#$(TZ=Europe/Amsterdam date +%m)))
+          DOW=$((10#$(TZ=Europe/Amsterdam date +%u)))
+          DOM=$((10#$(TZ=Europe/Amsterdam date +%e | tr -d ' ')))
+          HOUR=$((10#$(TZ=Europe/Amsterdam date +%H)))
+          MIN=$((10#$(TZ=Europe/Amsterdam date +%M)))
+          TOTAL=$((HOUR * 60 + MIN))
+
+          WANT_MONTH=false
+          for M in 2 5 8 11; do
+            if [[ "${MONTH}" -eq "${M}" ]]; then WANT_MONTH=true; break; fi
+          done
+
+          if [[ "${WANT_MONTH}" != 'true' ]] || [[ "${DOW}" -ne 6 ]] || [[ "${DOM}" -gt 7 ]]; then
+            echo 'should_run=false' >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          # ~05:15–05:59 local — tune if DST edge duplicates fire.
+          if [[ "${TOTAL}" -lt 315 ]] || [[ "${TOTAL}" -gt 359 ]]; then
+            echo 'should_run=false' >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo 'should_run=true' >>"${GITHUB_OUTPUT}"
+
+      - name: Checkout repo (issue body template)
+        if: ${{ steps.slot.outputs.should_run == 'true' }}
+        uses: actions/checkout@v6
+
+      - name: Open maintenance reminder issue
+        if: ${{ steps.slot.outputs.should_run == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod +x .github/scripts/render-maintenance-issue-body.sh
+          chmod +x .github/scripts/render-maintenance-issue-body.sh || true
+          BODY_FILE="$(mktemp)"
+          ./.github/scripts/render-maintenance-issue-body.sh >"${BODY_FILE}"
+          TITLE="$(printf 'Chore: periodic maintenance review (%s)' "$(TZ=Europe/Amsterdam date +"%Y-%m-%d Amsterdam")")"
+          OWNER="${GITHUB_REPOSITORY_OWNER:-pkuppens}"
+          gh issue create \
+            --assignee "${OWNER}" \
+            --label chore \
+            --label maintenance \
+            --title "${TITLE}" \
+            --body-file "${BODY_FILE}"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -6,8 +6,8 @@
 # (expected >= 2026-06-02). Preconditions before removing:
 #   1. Date >= 2026-06-02 (forced Node 24 default date per GitHub changelog).
 #   2. ubuntu-latest runner images no longer warn about Node.js 20 deprecation.
-#   3. actions/checkout@v4 (or newer) ships a Node 24 runtime (verify release notes).
-#   4. actions/setup-node@v4 (or newer) ships a Node 24 runtime (verify release notes).
+#   3. actions/checkout@v6 (or newer) ships a Node 24 runtime for the shim (verify release notes).
+#   4. actions/setup-node@v6 (or newer) ships a Node 24 runtime for the shim (verify release notes).
 #   5. A workflow_dispatch run WITHOUT FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 produces no Node 20 warning.
 # See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
 name: Security audit
@@ -27,10 +27,10 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: npm

--- a/.github/workflows/site-health.yml
+++ b/.github/workflows/site-health.yml
@@ -23,10 +23,10 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: npm

--- a/e2e/site-health.spec.ts
+++ b/e2e/site-health.spec.ts
@@ -25,7 +25,8 @@ test('live site renders content and nav works', async ({ page, request }) => {
   await expect(page.getByRole('heading', { level: 1, name: /Pieter Kuppens/i })).toBeVisible()
 
   // Click-through checks (SPA navigation via header links)
-  await page.getByRole('link', { name: 'Profile' }).click()
+  // exact: header link is "Profile"; hero also has "View Profile" — substring matching would resolve to two nodes.
+  await page.getByRole('link', { name: 'Profile', exact: true }).click()
   await expect(page.getByRole('heading', { level: 2, name: 'Work Preferences' })).toBeVisible()
 
   await page.getByRole('link', { name: 'Projects' }).click()


### PR DESCRIPTION
## Summary
Implements the site health portfolio plan (e2e fix, templates, Actions v6, periodic maintenance reminder).

## Changes
- **#30** — Playwright: use `exact` on the nav Profile link so it does not match the hero ''View Profile'' CTA.
- **#29** — Issue chooser `config.yml`; generic BUG; FEATURE / TASK / CHORE templates; specialised blank-pages template tweaks; **[CHORE] Periodic maintenance review** checklist template.
- **#32** — `maintenance-reminder.yml`: quarterly gate (Feb/May/Aug/Nov, first Saturday, Amsterdam morning window); opens an issue via `gh issue create` from `.github/templates/maintenance-issue-body.md`.
- **#31** — Bump `actions/checkout` and `actions/setup-node` from v4 to **v6** on deploy, site-health, and security-audit workflows (maintenance-reminder already uses checkout v6).

Closes #29
Closes #30
Closes #31
Closes #32