### PR TITLE
#34: fix SPA deep links on GitHub Pages (404.html fallback)

### DIFF
--- a/e2e/site-health.spec.ts
+++ b/e2e/site-health.spec.ts
@@ -25,7 +25,7 @@ test('live site renders content and nav works', async ({ page, request }) => {
   await expect(page.getByRole('heading', { level: 1, name: /Pieter Kuppens/i })).toBeVisible()
 
   // Click-through checks (SPA navigation via header links)
-  await page.getByRole('link', { name: 'Profile' }).click()
+  await page.getByRole('link', { name: 'Profile', exact: true }).click()
   await expect(page.getByRole('heading', { level: 2, name: 'Work Preferences' })).toBeVisible()
 
   await page.getByRole('link', { name: 'Projects' }).click()
@@ -33,5 +33,14 @@ test('live site renders content and nav works', async ({ page, request }) => {
 
   await page.getByRole('link', { name: 'Opportunity Evaluator' }).click()
   await expect(page.getByRole('heading', { level: 1, name: /Opportunity Evaluator/i })).toBeVisible()
+})
+
+test('deep link /profile loads SPA (GitHub Pages 404.html shell)', async ({ page }) => {
+  const profileUrl = new URL('/profile', LIVE_URL).href
+  await page.goto(profileUrl, { waitUntil: 'domcontentloaded' })
+  // Pages may respond 404 while still serving 404.html as the app shell; the client router must run.
+  await expect(page.getByRole('heading', { level: 2, name: 'Work Preferences' })).toBeVisible({
+    timeout: 20_000,
+  })
 })
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import reactRefresh from "eslint-plugin-react-refresh";
 
 export default [
   {
-    ignores: ["dist/**", "node_modules/**"],
+    ignores: ["dist/**", "node_modules/**", "scripts/**"],
   },
   js.configs.recommended,
   {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node scripts/copy-github-pages-spa-fallback.mjs",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/copy-github-pages-spa-fallback.mjs
+++ b/scripts/copy-github-pages-spa-fallback.mjs
@@ -1,0 +1,21 @@
+/**
+ * GitHub Pages has no filesystem route for SPA paths like /profile. It serves index.html only for /.
+ * Copying the built shell to 404.html makes unknown paths serve the same bundle; the client router
+ * then resolves the pathname. See: GitHub Docs — custom 404 for Project Pages user sites.
+ */
+import { copyFileSync, existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const dist = join(here, '..', 'dist')
+const indexHtml = join(dist, 'index.html')
+const notFound = join(dist, '404.html')
+
+if (!existsSync(indexHtml)) {
+  console.error('copy-github-pages-spa-fallback: dist/index.html missing; run vite build first.')
+  process.exit(1)
+}
+
+copyFileSync(indexHtml, notFound)
+console.log('copy-github-pages-spa-fallback: wrote dist/404.html from dist/index.html')


### PR DESCRIPTION
## Summary
GitHub Pages only served `/index.html` for `/`; direct load or reload of client routes (`/profile`, etc.) returned GitHub's generic 404 with no SPA shell.

## Changes
- After `vite build`, copy `dist/index.html` to `dist/404.html` so Pages serves the same React bundle on unknown paths (see GitHub docs: custom 404 for Pages).
- E2E: deep-link smoke for `/profile`; Profile nav locator uses `exact: true` (avoid matching "View Profile").

## Note
Until this is deployed, `npm run test:site-health` may fail the deep-link test against production — expect green after merge and Pages deploy.

Closes #34
