### PR TITLE
#37: Dark-first theming, <... /> links, and remove icons

### DIFF
--- a/src/components/layout/Footer.module.css
+++ b/src/components/layout/Footer.module.css
@@ -1,6 +1,6 @@
 .footer {
-  background: var(--color-text);
-  color: rgba(255,255,255,0.7);
+  background: var(--footer-bg);
+  color: var(--footer-text);
   padding: 1.5rem 0;
   margin-top: auto;
 }
@@ -23,10 +23,24 @@
 }
 
 .links a {
-  color: rgba(255,255,255,0.7);
+  color: var(--footer-text);
   font-size: 0.875rem;
   text-decoration: none;
   transition: color 0.15s;
+}
+
+.links a::before {
+  content: '<';
+  font-family: var(--font-mono);
+  color: color-mix(in srgb, var(--footer-text) 85%, #ffffff 15%);
+  margin-right: 0.25rem;
+}
+
+.links a::after {
+  content: ' />';
+  font-family: var(--font-mono);
+  color: color-mix(in srgb, var(--footer-text) 85%, #ffffff 15%);
+  margin-left: 0.25rem;
 }
 
 .links a:hover {

--- a/src/components/layout/Header.module.css
+++ b/src/components/layout/Header.module.css
@@ -2,9 +2,9 @@
   position: sticky;
   top: 0;
   z-index: 100;
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--header-bg);
   backdrop-filter: blur(8px);
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--header-border);
   box-shadow: var(--shadow-sm);
 }
 
@@ -42,6 +42,30 @@
   gap: 0.25rem;
 }
 
+.themeToggle {
+  margin-left: 0.5rem;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  border-radius: var(--radius);
+  padding: 0.35rem 0.55rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.themeToggle:hover {
+  color: var(--color-text);
+  background: var(--nav-hover-bg);
+  border-color: color-mix(in srgb, var(--color-border) 60%, var(--color-primary) 40%);
+}
+
+.themeToggle:focus-visible {
+  outline: 3px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
 .link, .activeLink {
   padding: 0.4rem 0.8rem;
   border-radius: var(--radius);
@@ -52,15 +76,36 @@
   transition: color 0.15s, background 0.15s;
 }
 
+.link::before,
+.activeLink::before {
+  content: '<';
+  font-family: var(--font-mono);
+  color: color-mix(in srgb, var(--color-text-muted) 70%, var(--color-primary) 30%);
+  margin-right: 0.25rem;
+}
+
+.link::after,
+.activeLink::after {
+  content: ' />';
+  font-family: var(--font-mono);
+  color: color-mix(in srgb, var(--color-text-muted) 70%, var(--color-primary) 30%);
+  margin-left: 0.25rem;
+}
+
 .link:hover {
   color: var(--color-primary);
-  background: #eff6ff;
+  background: var(--nav-hover-bg);
   text-decoration: none;
 }
 
 .activeLink {
   color: var(--color-primary);
-  background: #eff6ff;
+  background: var(--nav-hover-bg);
+}
+
+.activeLink::before,
+.activeLink::after {
+  color: color-mix(in srgb, var(--color-primary) 70%, var(--color-text-muted) 30%);
 }
 
 .cta {
@@ -81,5 +126,8 @@
   .link, .activeLink {
     padding: 0.4rem 0.5rem;
     font-size: 0.82rem;
+  }
+  .themeToggle {
+    margin-left: 0.25rem;
   }
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,32 @@
 import { NavLink } from 'react-router-dom'
+import { useEffect, useState } from 'react'
 import styles from './Header.module.css'
 
+type Theme = 'light' | 'dark'
+
+function getCurrentTheme(): Theme {
+  const t = document.documentElement.dataset.theme
+  return t === 'dark' ? 'dark' : 'light'
+}
+
+function setTheme(theme: Theme) {
+  document.documentElement.dataset.theme = theme
+  localStorage.setItem('theme', theme)
+}
+
 export default function Header() {
+  const [theme, setThemeState] = useState<Theme>(() => getCurrentTheme())
+
+  useEffect(() => {
+    setThemeState(getCurrentTheme())
+  }, [])
+
+  function onToggleTheme() {
+    const next = theme === 'dark' ? 'light' : 'dark'
+    setTheme(next)
+    setThemeState(next)
+  }
+
   return (
     <header className={styles.header}>
       <div className={`container ${styles.inner}`}>
@@ -23,6 +48,14 @@ export default function Header() {
           <NavLink to="/evaluator" className={({ isActive }) => isActive ? `${styles.activeLink} ${styles.cta}` : `${styles.link} ${styles.cta}`}>
             Opportunity Evaluator
           </NavLink>
+          <button
+            type="button"
+            className={styles.themeToggle}
+            onClick={onToggleTheme}
+            aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme`}
+          >
+            {theme === 'dark' ? 'Dark' : 'Light'}
+          </button>
         </nav>
       </div>
     </header>

--- a/src/components/layout/__tests__/HeaderFooter.test.tsx
+++ b/src/components/layout/__tests__/HeaderFooter.test.tsx
@@ -26,6 +26,11 @@ describe('Header', () => {
     expect(screen.getByRole('link', { name: /Opportunity Evaluator/i })).toBeInTheDocument()
   })
 
+  it('renders a theme toggle button', () => {
+    renderHeader()
+    expect(screen.getByRole('button', { name: /Switch to/i })).toBeInTheDocument()
+  })
+
   it('Home link points to /', () => {
     renderHeader()
     expect(screen.getByRole('link', { name: /^Home$/i })).toHaveAttribute('href', '/')

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,22 @@
   --color-text: #1e293b;
   --color-text-muted: #64748b;
   --color-border: #e2e8f0;
+  --color-surface-2: #f1f5f9;
+  --color-focus-ring: rgba(37, 99, 235, 0.35);
+
+  --header-bg: rgba(255, 255, 255, 0.95);
+  --header-border: var(--color-border);
+  --nav-hover-bg: #eff6ff;
+
+  --tag-bg: #eff6ff;
+  --tag-border: #bfdbfe;
+  --tag-text: var(--color-primary);
+
+  --footer-bg: var(--color-text);
+  --footer-text: rgba(255, 255, 255, 0.7);
+
+  --cta-bg-start: #f0f9ff;
+  --cta-bg-end: #eff6ff;
   --radius: 8px;
   --radius-lg: 16px;
   --shadow-sm: 0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.04);
@@ -18,6 +34,32 @@
   --shadow-lg: 0 10px 25px rgba(0,0,0,.12), 0 4px 10px rgba(0,0,0,.06);
   --font-sans: 'Segoe UI', system-ui, -apple-system, sans-serif;
   --font-mono: 'Fira Code', 'Cascadia Code', monospace;
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+
+  --color-bg: #060b15;
+  --color-surface: #0b1220;
+  --color-surface-2: #0f172a;
+  --color-text: #e2e8f0;
+  --color-text-muted: #94a3b8;
+  --color-border: #1f2a44;
+  --color-focus-ring: rgba(56, 189, 248, 0.35);
+
+  --header-bg: rgba(6, 11, 21, 0.72);
+  --header-border: var(--color-border);
+  --nav-hover-bg: rgba(37, 99, 235, 0.16);
+
+  --tag-bg: rgba(37, 99, 235, 0.16);
+  --tag-border: rgba(37, 99, 235, 0.35);
+  --tag-text: #c7d2fe;
+
+  --footer-bg: #060b15;
+  --footer-text: rgba(226, 232, 240, 0.7);
+
+  --cta-bg-start: rgba(37, 99, 235, 0.10);
+  --cta-bg-end: rgba(20, 184, 166, 0.08);
 }
 
 * {
@@ -145,12 +187,12 @@ img {
 .tag {
   display: inline-block;
   padding: 0.2em 0.6em;
-  background: #eff6ff;
-  color: var(--color-primary);
+  background: var(--tag-bg);
+  color: var(--tag-text);
   border-radius: var(--radius);
   font-size: 0.8rem;
   font-weight: 500;
-  border: 1px solid #bfdbfe;
+  border: 1px solid var(--tag-border);
 }
 
 .grid-2 {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,18 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
 
+function applyInitialTheme() {
+  const stored = localStorage.getItem('theme')
+  if (stored === 'light' || stored === 'dark') {
+    document.documentElement.dataset.theme = stored
+    return
+  }
+
+  document.documentElement.dataset.theme = 'dark'
+}
+
+applyInitialTheme()
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />

--- a/src/pages/HomePage.module.css
+++ b/src/pages/HomePage.module.css
@@ -49,6 +49,23 @@
   margin-top: 0;
 }
 
+:global(.btn-outline).heroOutlineBtn {
+  color: rgba(255, 255, 255, 0.92);
+  border-color: rgba(255, 255, 255, 0.72);
+  background: transparent;
+}
+
+:global(.btn-outline).heroOutlineBtn:hover {
+  color: #0b1220;
+  background: rgba(255, 255, 255, 0.92);
+  border-color: rgba(255, 255, 255, 0.92);
+}
+
+.heroOutlineBtn:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.4);
+  outline-offset: 2px;
+}
+
 .sectionTitle {
   font-size: 1.75rem;
   color: var(--color-text);
@@ -58,10 +75,6 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-}
-
-.highlightIcon {
-  font-size: 2rem;
 }
 
 .highlightTitle {
@@ -116,7 +129,7 @@
 }
 
 .ctaSection {
-  background: linear-gradient(135deg, #f0f9ff, #eff6ff);
+  background: linear-gradient(135deg, var(--cta-bg-start), var(--cta-bg-end));
 }
 
 .ctaTitle {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -14,22 +14,18 @@ const SKILLS = [
 
 const HIGHLIGHTS = [
   {
-    icon: '🤖',
     title: 'Applied AI (LLM + non-LLM)',
     desc: 'Built GenAI and RAG solutions, and non-LLM systems for deep learning, NLP support, and transaction monitoring.',
   },
   {
-    icon: '🗄️',
     title: 'Data and SQL Engineering',
     desc: 'Designed and optimized SQL-heavy backends, data pipelines, and integration workflows across enterprise and SME systems.',
   },
   {
-    icon: '🧪',
     title: 'Scientific and Regulated Software',
     desc: 'Delivered medical and high-tech software with quality process awareness in ISO 13485 and IEC 62304 contexts.',
   },
   {
-    icon: '🤝',
     title: 'Leadership and Delivery',
     desc: 'Hands-on engineer who mentors teammates, supports architecture decisions, and improves team workflows.',
   },
@@ -64,9 +60,9 @@ export default function HomePage() {
             </div>
             <div className={`flex flex-wrap gap-2 ${styles.heroCtas}`}>
               <Link to="/evaluator" className="btn btn-primary">
-                🎯 Evaluate Your Opportunity
+                Evaluate Your Opportunity
               </Link>
-              <Link to="/profile" className="btn btn-outline">
+              <Link to="/profile" className={`btn btn-outline ${styles.heroOutlineBtn}`}>
                 View Profile
               </Link>
             </div>
@@ -81,7 +77,6 @@ export default function HomePage() {
           <div className="grid-2">
             {HIGHLIGHTS.map(h => (
               <div key={h.title} className={`card ${styles.highlightCard}`}>
-                <div className={styles.highlightIcon}>{h.icon}</div>
                 <h3 className={styles.highlightTitle}>{h.title}</h3>
                 <p className="text-muted">{h.desc}</p>
               </div>
@@ -126,7 +121,7 @@ export default function HomePage() {
             Use the interactive Opportunity Evaluator to see how well an assignment matches my profile.
           </p>
           <Link to="/evaluator" className="btn btn-primary">
-            Open Opportunity Evaluator →
+            Open Opportunity Evaluator
           </Link>
         </div>
       </section>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -16,13 +16,6 @@ const EXPERIENCE = [
     tags: ['Healthcare', 'AI', 'Python', 'Data'],
   },
   {
-    period: '2013 – Present',
-    role: 'Software and Data Professional',
-    company: 'pieterkuppens.net (Self-employed/Freelance)',
-    desc: 'Long-running independent practice delivering software and data projects for different industries.',
-    tags: ['Python', 'C#', 'SQL', 'Freelance'],
-  },
-  {
     period: '2022 – 2025',
     role: 'AI Transaction Monitoring Workflow Optimization',
     company: 'Rent a Pin',
@@ -44,6 +37,55 @@ const EXPERIENCE = [
     tags: ['ISO 13485', 'IEC 62304', 'Python', 'Coaching'],
   },
   {
+    period: 'Feb 2018 – Oct 2018',
+    role: 'Software en Data Professional',
+    company: 'Isatis Health',
+    desc: 'Short assignment in a healthcare context with a focus on practical software delivery and data-oriented work.',
+    tags: ['Healthcare', 'Software Engineering', 'Data'],
+  },
+  {
+    period: 'May 2013 – Jul 2018',
+    role: 'Senior Software Engineer (part-time)',
+    company: 'Ratho BV',
+    desc: 'Part-time side job focused on C/C++ and SQL-heavy engineering, mentoring, and delivery support.',
+    tags: ['C#', 'SQL', 'Mentoring', 'Part-time (5-10%)'],
+  },
+  {
+    period: 'Apr 2013 – Present',
+    role: 'Software en Data Professional (self-employed)',
+    company: 'pieterkuppens.net',
+    desc: 'Independent practice delivering software and data projects across healthcare, finance, and high-tech.',
+    tags: ['Freelance', 'Python', 'C#/.NET', 'C/C++', 'SQL'],
+  },
+  {
+    period: 'Dec 2012 – Apr 2013',
+    role: 'Technical Engineer',
+    company: 'Blueriq',
+    desc: 'Short assignment focusing on frontend-oriented engineering in a professional software environment.',
+    tags: ['Frontend', 'WPF', 'HTML/CSS'],
+  },
+  {
+    period: 'Jul 2012 – Nov 2012',
+    role: 'Technical Engineer',
+    company: 'ABN AMRO Bank',
+    desc: 'Engineering work in a banking environment with focus on secure enterprise delivery.',
+    tags: ['Security', 'Enterprise', 'C#/.NET', 'MSSQL'],
+  },
+  {
+    period: 'Apr 2012 – Jun 2012',
+    role: 'Security Specialist',
+    company: 'ABN AMRO Lease',
+    desc: 'Security-focused work including SMS 2FA and password policy improvements.',
+    tags: ['Security', '2FA', 'Policies'],
+  },
+  {
+    period: 'Apr 2012 – Apr 2013',
+    role: 'Technical Engineer',
+    company: 'Everest BV',
+    desc: 'Technical engineering role across a one-year period (overlapping with short assignments).',
+    tags: ['Engineering', 'Consulting'],
+  },
+  {
     period: '2011 – 2012',
     role: 'Software Designer',
     company: 'Philips Healthcare',
@@ -51,18 +93,18 @@ const EXPERIENCE = [
     tags: ['Healthcare', 'Scientific Software', 'C/C++', 'Visualization'],
   },
   {
-    period: '1997 – 2014',
+    period: '2010',
+    role: 'Software Engineer',
+    company: 'BOSOR',
+    desc: 'Contributed to frontend to planning software',
+    tags: ['Delphi', 'JavaScript'],
+  },
+  {
+    period: '1997 – 2009',
     role: 'Software Designer',
     company: 'ASML',
     desc: 'Long-tenure high-tech engineering on complex software projects in large-scale semiconductor systems.',
     tags: ['High-Tech', 'C/C++', 'Engineering', 'Long-term'],
-  },
-  {
-    period: '2012',
-    role: 'Technical Engineer and Security Specialist',
-    company: 'ABN AMRO and ABN AMRO Lease',
-    desc: 'Implemented secure enterprise features including SMS 2FA and password policy improvements.',
-    tags: ['Security', '2FA', 'C#', 'MSSQL'],
   },
 ]
 
@@ -77,7 +119,7 @@ const PREFERENCES = [
 
 const TECH = {
   'Core Languages': ['Python', 'C#/.NET', 'C/C++', 'SQL', 'JavaScript'],
-  'Data and AI': ['GenAI / LLM / RAG', 'Deep Learning', 'NLP Support', 'Transaction Monitoring AI', 'Data Pipelines'],
+  'Data and AI': ['GenAI', 'LLM', 'RAG', 'AI-assisted development', 'Deep Learning', 'NLP Support', 'Transaction Monitoring AI', 'Data Pipelines'],
   'Cloud and DevOps': ['Azure', 'AWS', 'CI/CD', 'Docker', 'Jira/Confluence/Bitbucket'],
   'Security and Compliance': ['SMS 2FA', 'Password Policies', 'ISO 13485 Context', 'IEC 62304 Context'],
   'Databases and Storage': ['MSSQL', 'SQLite', 'MySQL', 'PostgreSQL'],

--- a/src/pages/ProjectsPage.module.css
+++ b/src/pages/ProjectsPage.module.css
@@ -33,10 +33,6 @@
   margin-bottom: 0.75rem;
 }
 
-.projectIcon {
-  font-size: 2rem;
-}
-
 .projectTitle {
   font-size: 1.3rem;
   font-weight: 700;

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -5,7 +5,6 @@ const PROJECTS = [
   {
     slug: 'on-prem-rag',
     title: 'On-Prem RAG for Healthcare',
-    icon: '🏥',
     status: 'Active',
     desc: 'Problem: healthcare teams need private AI search over internal knowledge. Approach: on-prem RAG pipeline with grounded answers and citations. Outcome: practical GenAI proof in a privacy-sensitive domain.',
     tags: ['Python', 'RAG', 'Healthcare', 'On-Prem'],
@@ -15,7 +14,6 @@ const PROJECTS = [
   {
     slug: 'transaction-monitoring',
     title: 'Transaction Monitoring ML/AI',
-    icon: '💳',
     status: 'Active',
     desc: 'Problem: detect risky transaction patterns and improve monitoring workflows. Approach: MLFlow-based experimentation and operational workflow support. Outcome: stronger evidence for non-LLM AI in finance.',
     tags: ['MLFlow', 'Fraud Detection', 'Finance', 'Python'],
@@ -25,7 +23,6 @@ const PROJECTS = [
   {
     slug: 'medical-imaging',
     title: 'Medical Imaging Deep Learning',
-    icon: '🫀',
     status: 'Case Study',
     desc: 'Problem: support cardiac intervention planning with better image understanding. Approach: deep-learning segmentation on DICOM MRI and cloud migration support. Outcome: production-oriented non-LLM AI in medtech.',
     tags: ['Deep Learning', 'DICOM', 'MRI', 'AWS'],
@@ -35,7 +32,6 @@ const PROJECTS = [
   {
     slug: 'evaluator',
     title: 'Opportunity Evaluator',
-    icon: '🎯',
     status: 'Live',
     desc: 'An interactive tool that scores assignment fit based on configurable criteria: domain, rate, commute, technology, and more. Built with React and TypeScript with pure-function scoring logic.',
     tags: ['React', 'TypeScript', 'Scoring Engine', 'localStorage'],
@@ -45,7 +41,6 @@ const PROJECTS = [
   {
     slug: 'healthcare-ai-agent',
     title: 'Healthcare AI Agent PoC',
-    icon: '🧭',
     status: 'Active',
     desc: 'Problem: explore AI-agent support in healthcare context. Approach: proof-of-concept agent architecture and domain workflows. Outcome: practical baseline for future healthcare AI solutions.',
     tags: ['Healthcare', 'AI Agent', 'PoC', 'Python'],
@@ -72,7 +67,6 @@ export default function ProjectsPage() {
             {PROJECTS.map(project => (
               <div key={project.slug} className={`card ${styles.projectCard}`}>
                 <div className={styles.projectHeader}>
-                  <span className={styles.projectIcon}>{project.icon}</span>
                   <span className={`badge ${project.status === 'Live' ? '' : 'badge-secondary'}`}>
                     {project.status}
                   </span>
@@ -84,11 +78,11 @@ export default function ProjectsPage() {
                 </div>
                 {project.isInternal ? (
                   <Link to={project.link} className="btn btn-primary">
-                    Open Demo →
+                    Open Demo
                   </Link>
                 ) : (
                   <a href={project.link} target="_blank" rel="noopener noreferrer" className="btn btn-outline">
-                    View on GitHub ↗
+                    View on GitHub
                   </a>
                 )}
               </div>

--- a/src/pages/evaluator/EvaluatorForm.tsx
+++ b/src/pages/evaluator/EvaluatorForm.tsx
@@ -217,7 +217,7 @@ export default function EvaluatorForm({ initialInput, onEvaluate, onReset }: Pro
 
       <div className={styles.actions}>
         <button type="submit" className="btn btn-primary">
-          🎯 Evaluate
+          Evaluate
         </button>
         <button type="button" className="btn btn-outline" onClick={handleReset}>
           Reset

--- a/src/pages/evaluator/EvaluatorPage.tsx
+++ b/src/pages/evaluator/EvaluatorPage.tsx
@@ -58,7 +58,7 @@ export default function EvaluatorPage() {
     <>
       <section className={styles.hero}>
         <div className="container">
-          <h1 className={styles.title}>🎯 Opportunity Evaluator</h1>
+          <h1 className={styles.title}>Opportunity Evaluator</h1>
           <p className={styles.subtitle}>
             Score any assignment against your profile criteria — rate, domain, commute, hybrid arrangement, tech stack and more.
           </p>
@@ -80,7 +80,7 @@ export default function EvaluatorPage() {
               onClick={() => setActiveTab('preferences')}
               aria-selected={activeTab === 'preferences'}
             >
-              ⚙️ My Preferences
+              My Preferences
             </button>
           </div>
 

--- a/src/pages/evaluator/EvaluatorResults.tsx
+++ b/src/pages/evaluator/EvaluatorResults.tsx
@@ -6,10 +6,10 @@ interface Props {
 }
 
 const LEVEL_CONFIG: Record<ScoreLevel, { label: string; color: string; bg: string }> = {
-  excellent: { label: '🌟 Excellent Fit', color: '#16a34a', bg: '#f0fdf4' },
-  good: { label: '✅ Good Fit', color: '#2563eb', bg: '#eff6ff' },
-  fair: { label: '⚠️ Fair Fit', color: '#d97706', bg: '#fffbeb' },
-  poor: { label: '❌ Poor Fit', color: '#dc2626', bg: '#fef2f2' },
+  excellent: { label: 'Excellent fit', color: '#16a34a', bg: '#f0fdf4' },
+  good: { label: 'Good fit', color: '#2563eb', bg: '#eff6ff' },
+  fair: { label: 'Fair fit', color: '#d97706', bg: '#fffbeb' },
+  poor: { label: 'Poor fit', color: '#dc2626', bg: '#fef2f2' },
 }
 
 function ScoreBar({ score, color }: { score: number; color: string }) {

--- a/src/pages/evaluator/__tests__/EvaluatorResults.test.tsx
+++ b/src/pages/evaluator/__tests__/EvaluatorResults.test.tsx
@@ -45,22 +45,22 @@ describe('EvaluatorResults', () => {
 
   it('renders excellent level label', () => {
     render(<EvaluatorResults result={excellentResult} />)
-    expect(screen.getByText('🌟 Excellent Fit')).toBeInTheDocument()
+    expect(screen.getByText('Excellent fit')).toBeInTheDocument()
   })
 
   it('renders poor level label', () => {
     render(<EvaluatorResults result={poorResult} />)
-    expect(screen.getByText('❌ Poor Fit')).toBeInTheDocument()
+    expect(screen.getByText('Poor fit')).toBeInTheDocument()
   })
 
   it('renders fair level label', () => {
     render(<EvaluatorResults result={fairResult} />)
-    expect(screen.getByText('⚠️ Fair Fit')).toBeInTheDocument()
+    expect(screen.getByText('Fair fit')).toBeInTheDocument()
   })
 
   it('renders good level label', () => {
     render(<EvaluatorResults result={goodResult} />)
-    expect(screen.getByText('✅ Good Fit')).toBeInTheDocument()
+    expect(screen.getByText('Good fit')).toBeInTheDocument()
   })
 
   it('renders the recommendation text', () => {


### PR DESCRIPTION
Closes #37

## Summary
- Add CSS-variable based dark/light theme system with a header toggle and **dark default**.
- Align header and footer link styling with the `<... />` motif (via CSS `::before/::after`).
- Improve Home hero outline button contrast (non-hover).
- Remove all emojis/icons/arrows from UI (Home, Projects, Evaluator) and update tests.
- Update Profile experience timeline to cover the 2012–2018 gap.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run build`
- [ ] Manual: toggle theme, confirm no emoji glyphs anywhere, and check Home/Profile/Projects/Evaluator pages.

Made with [Cursor](https://cursor.com)