### PR TITLE
#41: LinkedIn experience tooling + pivot docs (superseded by #42)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ coverage
 # Playwright
 playwright-report
 test-results
+
+# Local scratch (LinkedIn scrape output, persistent browser profile)
+tmp/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ echo "npm run typecheck && npm test" > .husky/pre-commit
 ## Architecture
 See [docs/arc42/architecture.md](docs/arc42/architecture.md) for full documentation.
 
+LinkedIn local mirror tooling (experience XSD, optional legacy scrape helpers): [`scripts/linkedin/README.md`](scripts/linkedin/README.md).
+
 ## ADRs
 - [ADR 001: React + TypeScript + Vite](docs/adr/001-react-typescript-vite.md)
 - [ADR 002: Pure Functions for Scoring](docs/adr/002-pure-functions-scoring.md)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:site-health": "playwright test e2e/site-health.spec.ts",
+    "linkedin:scrape": "node scripts/linkedin/scrape.mjs",
+    "linkedin:scrape:cdp": "node scripts/linkedin/scrape.mjs --cdp http://127.0.0.1:9222",
+    "linkedin:scrape:cdp:start": "node scripts/linkedin/scrape.mjs --start-chrome-cdp",
+    "linkedin:scrape:win": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/linkedin/linkedin-experience-from-chrome.ps1",
+    "linkedin:xml": "node scripts/linkedin/to-xml.mjs",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "typecheck": "tsc --noEmit"
   },

--- a/scripts/linkedin/README.md
+++ b/scripts/linkedin/README.md
@@ -1,0 +1,35 @@
+# LinkedIn — local structured experience data
+
+This folder holds tooling to turn **experience-shaped** content into validated XML aligned with LinkedIn-style fields (`schema.xsd` + `to-xml.mjs`). It exists so the repo can store a **local mirror** of your public CV data that stays close to what LinkedIn shows, without relying on fragile automation against linkedin.com.
+
+## Status (pivot away from scraping)
+
+Reliable **live scraping** of the LinkedIn Experience section (CDP-attached Chrome, selectors, logged-in DOM) proved **too brittle**: LinkedIn’s UI and protections change often; authentication and profile locks caused incomplete or inconsistent output. Issue **#41** is closed as *not planned* for that scrape-first goal.
+
+**Primary direction:** maintain canonical files under `data/linkedin/<vanitySlug>.xml` (plus JSON/CSV exports when implemented), populated through a **web or assistant-assisted editor** and manual verification — not headless scraping. Tracking: **[#42](https://github.com/pkuppens/pkuppens.github.io/issues/42)** (same repository).
+
+Legacy scrape scripts remain optional: they may still help if you save HTML to a fixture and run `linkedin:xml`, but they are **not** the supported path for day-to-day updates.
+
+## Layout and schema
+
+| File | Role |
+|------|------|
+| `schema.xsd` | XSD for `<lx:experiences>` — local data aligned with LinkedIn-style experience (including groups and roles). |
+| `to-xml.mjs` | Builds `tmp/linkedin.xml` from captured HTML (see npm `linkedin:xml`). |
+| `scrape.mjs` | Optional Playwright path; see header **Status** and limitations above. |
+| `linkedin-experience-from-chrome.ps1` / `.cmd` | Windows helpers to drive CDP + scrape + xml (legacy). |
+
+Target committed data (when the editor ships): **`data/linkedin/pieterkuppens.xml`** for [linkedin.com/in/pieterkuppens](https://www.linkedin.com/in/pieterkuppens/), with the same slug pattern for other profiles.
+
+## npm scripts (from repo root)
+
+- `npm run linkedin:scrape` — optional capture to `tmp/linkedin.html`
+- `npm run linkedin:scrape:cdp` / `linkedin:scrape:cdp:start` — CDP variants
+- `npm run linkedin:scrape:win` — PowerShell wrapper
+- `npm run linkedin:xml` — HTML → XML using `schema.xsd`
+
+Environment variables (`LINKEDIN_CDP_URL`, `LINKEDIN_USER_DATA_DIR`, etc.) are documented in the **`scrape.mjs`** file header.
+
+## Related GitHub tracking
+
+- **[#42](https://github.com/pkuppens/pkuppens.github.io/issues/42)** — web/AI-assisted editor and `data/linkedin/<slug>` mirror workflow

--- a/scripts/linkedin/linkedin-experience-from-chrome.cmd
+++ b/scripts/linkedin/linkedin-experience-from-chrome.cmd
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+REM Double-click friendly: runs PowerShell helper with execution policy bypass.
+cd /d "%~dp0..\.."
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0linkedin-experience-from-chrome.ps1" %*
+set EXIT=%ERRORLEVEL%
+if %EXIT% neq 0 pause
+exit /b %EXIT%

--- a/scripts/linkedin/linkedin-experience-from-chrome.ps1
+++ b/scripts/linkedin/linkedin-experience-from-chrome.ps1
@@ -1,0 +1,76 @@
+<#
+.SYNOPSIS
+  Start Chrome with CDP (optional), scrape LinkedIn experience, emit tmp/linkedin.xml.
+
+.DESCRIPTION
+  1) Close every Google Chrome window (profile lock otherwise).
+  2) Runs npm linkedin:scrape:cdp:start (--start-chrome-cdp) unless -AttachOnly.
+  3) Runs npm linkedin:xml.
+
+  Repo root is derived from this script location (…/scripts/linkedin → repo root).
+
+.PARAMETER AttachOnly
+  Do not spawn Chrome; expect CDP already at http://127.0.0.1:9222 (use linkedin:scrape:cdp).
+
+.PARAMETER CdpPort
+  Remote debugging port when starting or attaching (default 9222).
+
+.EXAMPLE
+  .\scripts\linkedin\linkedin-experience-from-chrome.ps1
+
+.EXAMPLE
+  .\scripts\linkedin\linkedin-experience-from-chrome.ps1 -AttachOnly
+#>
+param(
+  [switch] $AttachOnly,
+  [int] $CdpPort = 9222
+)
+
+$ErrorActionPreference = 'Stop'
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+Set-Location $RepoRoot
+
+function Test-Command($Name) {
+  return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+if (-not (Test-Command 'npm')) {
+  Write-Error 'npm not found. Install Node.js LTS and ensure npm is on PATH.'
+}
+
+Write-Host ''
+Write-Host 'LinkedIn experience scrape (Windows helper)' -ForegroundColor Cyan
+Write-Host "Repository: $RepoRoot"
+Write-Host ''
+Write-Host 'Important: quit Google Chrome completely before continuing (all windows).' -ForegroundColor Yellow
+Write-Host 'Press Enter when Chrome is closed, or Ctrl+C to cancel.'
+Read-Host | Out-Null
+
+$env:LINKEDIN_CDP_PORT = "$CdpPort"
+$cdpUrl = "http://127.0.0.1:$CdpPort"
+
+if ($AttachOnly) {
+  Write-Host "Attaching only (Chrome must already listen on $cdpUrl)..." -ForegroundColor Green
+  npm run linkedin:scrape -- --cdp $cdpUrl
+} else {
+  Write-Host "Starting Chrome with debug port $CdpPort (if not already listening), then scraping..." -ForegroundColor Green
+  npm run linkedin:scrape:cdp:start
+}
+
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "Scrape failed (exit $LASTEXITCODE). Fix Chrome/CDP, then retry."
+}
+
+Write-Host ''
+Write-Host 'Building tmp/linkedin.xml ...' -ForegroundColor Green
+npm run linkedin:xml
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "linkedin:xml failed (exit $LASTEXITCODE)."
+}
+
+$outXml = Join-Path $RepoRoot 'tmp\linkedin.xml'
+Write-Host ''
+Write-Host "Done. See: $outXml" -ForegroundColor Cyan
+if (Test-Path $outXml) {
+  Get-Item $outXml | Format-List FullName, Length, LastWriteTime
+}

--- a/scripts/linkedin/schema.xsd
+++ b/scripts/linkedin/schema.xsd
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Schema for LinkedIn experience export (scripts/linkedin/to-xml.mjs).
+  Dates use xs:gYearMonth on attributes so “present” roles use current=true without a bogus date.
+  Top-level experience vs experience inside experienceGroup share the element name but differ by context.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           targetNamespace="https://pkuppens.github.io/ns/linkedin-experience"
+           xmlns:lx="https://pkuppens.github.io/ns/linkedin-experience">
+
+  <xs:element name="experiences" type="lx:ExperiencesType"/>
+
+  <xs:complexType name="ExperiencesType">
+    <xs:sequence>
+      <xs:element name="meta" type="lx:MetaType" minOccurs="0"/>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="experience" type="lx:ExperienceType"/>
+        <xs:element name="experienceGroup" type="lx:ExperienceGroupType"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="MetaType">
+    <xs:attribute name="sourceUrl" type="xs:anyURI" use="optional"/>
+    <xs:attribute name="scrapedAt" type="xs:dateTime" use="optional"/>
+    <xs:attribute name="locale" type="xs:string" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="ExperienceType">
+    <xs:sequence>
+      <xs:element name="tagline" type="xs:string"/>
+      <xs:element name="company" type="xs:string"/>
+      <xs:element name="employmentType" type="xs:string" minOccurs="0"/>
+      <xs:element name="period" type="lx:PeriodType"/>
+      <xs:element name="location" type="xs:string" minOccurs="0"/>
+      <xs:element name="workMode" type="xs:string" minOccurs="0"/>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="tasks" type="lx:TasksType" minOccurs="0"/>
+      <xs:element name="skills" type="lx:SkillsType" minOccurs="0"/>
+      <xs:element name="skillsTruncatedSummary" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string" use="required"/>
+    <xs:attribute name="linkedinComponentKey" type="xs:string" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="ExperienceGroupType">
+    <xs:sequence>
+      <xs:element name="company" type="xs:string"/>
+      <xs:element name="groupSummary" type="lx:GroupSummaryType" minOccurs="0"/>
+      <xs:element name="location" type="xs:string" minOccurs="0"/>
+      <!-- Same NCName as top-level experience; valid as local element under experienceGroup only. -->
+      <xs:element name="experience" type="lx:GroupedExperienceType" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="linkedinComponentKey" type="xs:string" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="GroupSummaryType">
+    <xs:sequence>
+      <xs:element name="employmentType" type="xs:string" minOccurs="0"/>
+      <xs:element name="totalDurationText" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="GroupedExperienceType">
+    <xs:sequence>
+      <xs:element name="tagline" type="xs:string"/>
+      <xs:element name="period" type="lx:PeriodType"/>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="tasks" type="lx:TasksType" minOccurs="0"/>
+      <xs:element name="skills" type="lx:SkillsType" minOccurs="0"/>
+      <xs:element name="skillsTruncatedSummary" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="PeriodType">
+    <xs:sequence>
+      <xs:element name="startDate" type="lx:DateYmType" minOccurs="0"/>
+      <xs:element name="endDate" type="lx:EndDateYmType" minOccurs="0"/>
+      <xs:element name="duration" type="lx:DurationType" minOccurs="0"/>
+      <xs:element name="raw" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="DateYmType">
+    <xs:attribute name="yearMonth" type="xs:gYearMonth" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="EndDateYmType">
+    <xs:attribute name="yearMonth" type="xs:gYearMonth" use="optional"/>
+    <xs:attribute name="current" type="xs:boolean" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="DurationType">
+    <xs:attribute name="years" type="xs:nonNegativeInteger" use="optional"/>
+    <xs:attribute name="months" type="xs:nonNegativeInteger" use="optional"/>
+    <xs:attribute name="raw" type="xs:string" use="optional"/>
+  </xs:complexType>
+
+  <xs:complexType name="TasksType">
+    <xs:sequence>
+      <xs:element name="task" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="SkillsType">
+    <xs:sequence>
+      <xs:element name="skill" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>

--- a/scripts/linkedin/schema.xsd
+++ b/scripts/linkedin/schema.xsd
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Schema for LinkedIn experience export (scripts/linkedin/to-xml.mjs).
+  XSD for local Experience data modeled like LinkedIn (scripts/linkedin/to-xml.mjs).
+  Use for validated mirrors under data/linkedin/<slug>.xml, not only for scraped exports.
   Dates use xs:gYearMonth on attributes so “present” roles use current=true without a bogus date.
   Top-level experience vs experience inside experienceGroup share the element name but differ by context.
 -->

--- a/scripts/linkedin/scrape.mjs
+++ b/scripts/linkedin/scrape.mjs
@@ -1,4 +1,8 @@
 /**
+ * Status: Live LinkedIn scraping is legacy / best-effort (DOM and auth breakage). Prefer a local
+ * mirror edited via the web-assisted workflow tracked in scripts/linkedin/README.md. This script may
+ * still be useful with saved HTML fixtures and npm run linkedin:xml.
+ *
  * Capture LinkedIn experience details HTML (logged-in view) and optionally fetch
  * full skill lists per position via overlay URLs.
  *

--- a/scripts/linkedin/scrape.mjs
+++ b/scripts/linkedin/scrape.mjs
@@ -1,0 +1,461 @@
+/**
+ * Capture LinkedIn experience details HTML (logged-in view) and optionally fetch
+ * full skill lists per position via overlay URLs.
+ *
+ * Three ways to get past login:
+ *
+ * 1) Recommended — attach to your normal Chrome (cookies / password manager already there):
+ *    - Close every Chrome window (otherwise the profile is locked and debug start fails).
+ *    - Either let this script start Chrome in debug mode:
+ *        scripts/linkedin/linkedin-experience-from-chrome.cmd   (double-click or run from repo)
+ *        npm run linkedin:scrape:win
+ *        npm run linkedin:scrape:cdp:start
+ *        npm run linkedin:scrape -- --start-chrome-cdp
+ *        npm run linkedin:scrape -- --start-chrome-cdp --cdp-port 9223
+ *      Uses your real profile: %LOCALAPPDATA%\\Google\\Chrome\\User Data + profile Default
+ *      (override with LINKEDIN_USER_DATA_DIR / LINKEDIN_CHROME_PROFILE_DIR).
+ *    - Or start Chrome yourself, then run:
+ *        npm run linkedin:scrape:cdp
+ *        npm run linkedin:scrape -- --cdp http://127.0.0.1:9222
+ *        set LINKEDIN_CDP_URL=http://127.0.0.1:9222 && npm run linkedin:scrape
+ *    - Log in to LinkedIn in that window if needed.
+ *    This uses Playwright’s chromium.connectOverCDP() — the same Chrome DevTools Protocol
+ *    a debugger uses. It is not the same as the VS Code / Cursor “Connect to Playwright”
+ *    action, which attaches the test runner to @playwright/test; this script is plain Node.
+ *    Playwright only disconnects at the end; it does not close your Chrome.
+ *
+ * 2) Use your real Chrome profile folder with Playwright (Chrome must be fully closed):
+ *        set LINKEDIN_USER_DATA_DIR=%LOCALAPPDATA%\Google\Chrome\User Data
+ *        set LINKEDIN_CHROME_PROFILE_DIR=Default
+ *        npm run linkedin:scrape
+ *    Prefer a dedicated test profile if you want to avoid profile lock issues.
+ *
+ * 3) Isolated profile under tmp/.linkedin-profile (log in manually once; no env vars).
+ *
+ * Usage:
+ *   npm run linkedin:scrape
+ *   npm run linkedin:scrape -- --start-chrome-cdp
+ *   npm run linkedin:scrape -- --cdp http://127.0.0.1:9222
+ *   npm run linkedin:scrape -- --headless
+ *   npm run linkedin:scrape -- --headed
+ *   npm run linkedin:scrape -- --no-skills
+ *
+ * Default is headed when launching a new browser. --headed forces a window even if you passed --headless.
+ * With --cdp or LINKEDIN_CDP_URL, headless is ignored (you already started Chrome with a window).
+ *
+ * Env:
+ *   LINKEDIN_CDP_URL — e.g. http://127.0.0.1:9222 (same as --cdp; CLI wins if both are set).
+ *   LINKEDIN_CDP_PORT — default 9222 when using --start-chrome-cdp without --cdp URL.
+ *   LINKEDIN_USER_DATA_DIR — Chrome user data dir (default: OS Chrome profile path when using --start-chrome-cdp).
+ *   LINKEDIN_CHROME_PROFILE_DIR — e.g. Default or Profile 1 (with --start-chrome-cdp or persistent launch).
+ *   LINKEDIN_CHROME_EXECUTABLE — full path to chrome.exe if not found automatically.
+ *   LINKEDIN_EXPERIENCE_URL — defaults to pieterkuppens experience details page.
+ *   PLAYWRIGHT_USE_BUNDLED_CHROMIUM=1 — use Playwright’s Chromium instead of installed Google Chrome.
+ *   CHROME_CHANNEL — optional Playwright channel override (e.g. msedge); default is chrome when not bundled.
+ */
+import { chromium } from 'playwright'
+import { spawn } from 'node:child_process'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { JSDOM } from 'jsdom'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const tmpDir = join(repoRoot, 'tmp')
+const defaultUserDataDir = join(tmpDir, '.linkedin-profile')
+const outHtml = join(tmpDir, 'linkedin.html')
+const outSkills = join(tmpDir, 'linkedin.skills.json')
+
+const EXPERIENCE_URL =
+  process.env.LINKEDIN_EXPERIENCE_URL ??
+  'https://www.linkedin.com/in/pieterkuppens/details/experience/'
+
+function parseArgs(argv) {
+  const raw = argv.slice(2)
+  const args = new Set(raw)
+  const headed = args.has('--headed')
+  const headlessFlag = args.has('--headless')
+  const startChromeCdp = args.has('--start-chrome-cdp')
+  let cdpPort = parseInt(process.env.LINKEDIN_CDP_PORT ?? '9222', 10)
+  if (Number.isNaN(cdpPort) || cdpPort < 1 || cdpPort > 65535) cdpPort = 9222
+
+  let cdpUrl = (process.env.LINKEDIN_CDP_URL ?? '').trim()
+  for (let i = 0; i < raw.length; i++) {
+    if (raw[i] === '--cdp') {
+      const v = raw[i + 1]
+      if (v && !v.startsWith('--')) {
+        cdpUrl = v.trim()
+        i++
+      }
+    }
+    if (raw[i] === '--cdp-port') {
+      const v = raw[i + 1]
+      if (v && /^\d+$/.test(v)) {
+        cdpPort = parseInt(v, 10)
+        i++
+      }
+    }
+  }
+
+  if (startChromeCdp && !cdpUrl) {
+    cdpUrl = `http://127.0.0.1:${cdpPort}`
+  }
+
+  return {
+    /** Headed wins: visible browser for login and debugging. */
+    headless: headlessFlag && !headed,
+    noSkills: args.has('--no-skills'),
+    startChromeCdp,
+    cdpPort,
+    cdpUrl,
+  }
+}
+
+function defaultChromeUserDataDir() {
+  const fromEnv = (process.env.LINKEDIN_USER_DATA_DIR ?? '').trim()
+  if (fromEnv) return fromEnv
+  if (process.platform === 'win32') {
+    const la = process.env.LOCALAPPDATA
+    if (la) return join(la, 'Google', 'Chrome', 'User Data')
+  }
+  if (process.platform === 'darwin') {
+    return join(homedir(), 'Library', 'Application Support', 'Google', 'Chrome')
+  }
+  return join(homedir(), '.config', 'google-chrome')
+}
+
+function resolveChromeExecutable() {
+  const fromEnv = (process.env.LINKEDIN_CHROME_EXECUTABLE ?? '').trim()
+  if (fromEnv && existsSync(fromEnv)) return fromEnv
+  if (fromEnv) return fromEnv
+
+  if (process.platform === 'win32') {
+    const pf = process.env.PROGRAMFILES ?? 'C:\\Program Files'
+    const pfx86 = process.env['PROGRAMFILES(X86)'] ?? 'C:\\Program Files (x86)'
+    for (const p of [
+      join(pf, 'Google', 'Chrome', 'Application', 'chrome.exe'),
+      join(pfx86, 'Google', 'Chrome', 'Application', 'chrome.exe'),
+    ]) {
+      if (existsSync(p)) return p
+    }
+  }
+  if (process.platform === 'darwin') {
+    const p = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+    if (existsSync(p)) return p
+  }
+  return 'google-chrome'
+}
+
+function cdpHostPort(cdpUrl) {
+  const normalized = cdpUrl.includes('://') ? cdpUrl : `http://${cdpUrl}`
+  const u = new URL(normalized)
+  const port = u.port ? parseInt(u.port, 10) : 9222
+  return { host: u.hostname || '127.0.0.1', port, origin: u.origin }
+}
+
+async function cdpResponds(cdpUrl) {
+  const { host, port } = cdpHostPort(cdpUrl)
+  const base = `http://${host}:${port}`
+  try {
+    const r = await fetch(`${base}/json/version`, { signal: AbortSignal.timeout(2500) })
+    return r.ok
+  } catch {
+    return false
+  }
+}
+
+async function waitForCdp(cdpUrl, { timeoutMs = 60_000 } = {}) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await cdpResponds(cdpUrl)) return
+    await new Promise((r) => setTimeout(r, 400))
+  }
+  throw new Error(
+    `Chrome CDP did not respond at ${cdpUrl} within ${timeoutMs}ms. Close all Chrome windows and retry, or pick a free --cdp-port.`,
+  )
+}
+
+/**
+ * Start Google Chrome with remote debugging; detached so it keeps running after this script exits.
+ */
+function spawnChromeDebug({ executable, userDataDir, profileDir, port }) {
+  const args = [
+    `--remote-debugging-port=${port}`,
+    `--user-data-dir=${userDataDir}`,
+    `--profile-directory=${profileDir}`,
+    '--no-first-run',
+    '--no-default-browser-check',
+  ]
+  const child = spawn(executable, args, {
+    detached: true,
+    stdio: 'ignore',
+    windowsHide: false,
+  })
+  child.unref()
+  if (child.pid) {
+    console.log('linkedin/scrape: started Chrome pid', child.pid, 'port', port)
+  }
+}
+
+/** Extract skill names from LinkedIn overlay HTML (best-effort; markup changes often). */
+function parseSkillsFromOverlayHtml(html) {
+  const dom = new JSDOM(html)
+  const doc = dom.window.document
+  const found = new Set()
+
+  const push = (t) => {
+    const s = t.replace(/\s+/g, ' ').trim()
+    if (s && s.length > 0 && s.length < 120) found.add(s)
+  }
+
+  doc.querySelectorAll('[class*="skill"]').forEach((el) => push(el.textContent ?? ''))
+  doc.querySelectorAll('a[href*="/skills/"]').forEach((a) => push(a.textContent ?? ''))
+  doc.querySelectorAll('span[class*="white-space"]').forEach((el) => push(el.textContent ?? ''))
+
+  doc.querySelectorAll('li').forEach((li) => {
+    const t = li.textContent ?? ''
+    if (t.length > 2 && t.length < 100) push(t)
+  })
+
+  return [...found].sort((a, b) => a.localeCompare(b))
+}
+
+async function scrollUntilStable(page, selectorItems, { maxRounds = 30, stableNeed = 3 } = {}) {
+  let prev = 0
+  let stable = 0
+  for (let i = 0; i < maxRounds; i++) {
+    const count = await page.locator(selectorItems).count()
+    if (count === prev) stable++
+    else {
+      stable = 0
+      prev = count
+    }
+    if (stable >= stableNeed && count > 0) break
+
+    await page.evaluate(() => {
+      window.scrollBy(0, Math.floor(window.innerHeight * 1.25))
+    })
+    await new Promise((r) => setTimeout(r, 700))
+  }
+  return prev
+}
+
+/**
+ * Pick a tab to drive: prefer an existing LinkedIn tab, else the first tab, else a new page.
+ */
+async function obtainPage(context) {
+  const pages = context.pages()
+  const linkedIn = pages.find((p) => {
+    try {
+      return (p.url() ?? '').includes('linkedin.com')
+    } catch {
+      return false
+    }
+  })
+  if (linkedIn) {
+    await linkedIn.bringToFront().catch(() => {})
+    return linkedIn
+  }
+  if (pages.length > 0) {
+    await pages[0].bringToFront().catch(() => {})
+    return pages[0]
+  }
+  return context.newPage()
+}
+
+async function main() {
+  const { headless, noSkills, startChromeCdp, cdpUrl } = parseArgs(process.argv)
+  mkdirSync(tmpDir, { recursive: true })
+
+  const userDataDirResolved = (process.env.LINKEDIN_USER_DATA_DIR ?? defaultUserDataDir).trim()
+
+  let effectiveCdpUrl = cdpUrl
+
+  if (startChromeCdp) {
+    const { port } = cdpHostPort(effectiveCdpUrl)
+    const chromeUserData = defaultChromeUserDataDir()
+    const profileDir = (process.env.LINKEDIN_CHROME_PROFILE_DIR ?? 'Default').trim()
+    const executable = resolveChromeExecutable()
+
+    if (!chromeUserData) {
+      throw new Error(
+        'Could not resolve Chrome User Data path. Set LINKEDIN_USER_DATA_DIR to your Chrome "User Data" folder.',
+      )
+    }
+    if (!existsSync(chromeUserData)) {
+      throw new Error(
+        `Chrome user data folder not found: ${chromeUserData}\nSet LINKEDIN_USER_DATA_DIR to your Chrome "User Data" directory.`,
+      )
+    }
+
+    if (await cdpResponds(effectiveCdpUrl)) {
+      console.log('linkedin/scrape: CDP already listening at', effectiveCdpUrl, '(not starting a new Chrome)')
+    } else {
+      console.log('linkedin/scrape: starting Chrome with debug port', port)
+      console.log('linkedin/scrape: user-data-dir:', chromeUserData)
+      console.log('linkedin/scrape: profile-directory:', profileDir)
+      spawnChromeDebug({ executable, userDataDir: chromeUserData, profileDir, port })
+      await waitForCdp(effectiveCdpUrl)
+    }
+  }
+
+  console.log('linkedin/scrape: tmp dir:', tmpDir)
+  console.log(
+    'linkedin/scrape: mode:',
+    effectiveCdpUrl ? `CDP ${effectiveCdpUrl}` : `persistentContext ${userDataDirResolved}`,
+  )
+  console.log('linkedin/scrape: headless:', effectiveCdpUrl ? '(ignored; using your Chrome)' : headless)
+
+  let browserFromCdp = null
+  let context
+
+  if (effectiveCdpUrl) {
+    browserFromCdp = await chromium.connectOverCDP(effectiveCdpUrl)
+    const contexts = browserFromCdp.contexts()
+    if (contexts.length === 0) {
+      throw new Error(
+        'CDP: no browser contexts. Start Chrome with --remote-debugging-port=9222 and a normal profile, then retry.',
+      )
+    }
+    context = contexts[0]
+  } else {
+    const launchOpts = {
+      headless,
+      viewport: { width: 1280, height: 900 },
+    }
+    if (process.env.PLAYWRIGHT_USE_BUNDLED_CHROMIUM === '1') {
+      // Playwright-managed Chromium (no Google Chrome install required).
+    } else {
+      launchOpts.channel = process.env.CHROME_CHANNEL ?? 'chrome'
+    }
+    const extra = process.env.LINKEDIN_EXTRA_BROWSER_ARGS
+    if (extra) {
+      launchOpts.args = extra.split(',').map((s) => s.trim()).filter(Boolean)
+    }
+    if (process.env.LINKEDIN_CHROME_PROFILE_DIR) {
+      launchOpts.args = launchOpts.args ?? []
+      launchOpts.args.push(`--profile-directory=${process.env.LINKEDIN_CHROME_PROFILE_DIR}`)
+    }
+    context = await chromium.launchPersistentContext(userDataDirResolved, launchOpts)
+  }
+
+  const page = await obtainPage(context)
+
+  await page.goto(EXPERIENCE_URL, { waitUntil: 'domcontentloaded', timeout: 120_000 })
+
+  const loginLike =
+    page.url().includes('/login') ||
+    page.url().includes('/checkpoint') ||
+    (await page.locator('input#username, input[name="session_key"]').count()) > 0
+
+  if (loginLike) {
+    console.warn(
+      'linkedin/scrape: still on login or checkpoint. Complete login in the browser, then the script continues.',
+    )
+    if (!effectiveCdpUrl && !headless) {
+      await page.pause()
+    }
+    await page.waitForURL(/\/details\/experience\/?/, { timeout: 600_000 }).catch(() => {})
+    if (
+      page.url().includes('/login') ||
+      page.url().includes('/checkpoint') ||
+      (await page.locator('input#username, input[name="session_key"]').count()) > 0
+    ) {
+      console.warn(
+        'linkedin/scrape: hint: connect Playwright to your Chrome with --cdp http://127.0.0.1:9222 ' +
+          '(Chrome started with --remote-debugging-port=9222 and your User Data profile). ' +
+          'See script header comment.',
+      )
+    }
+  }
+
+  const section = page.locator('[data-testid^="profile_ExperienceDetailsSection"]')
+  await section.waitFor({ state: 'visible', timeout: 120_000 })
+
+  console.log('linkedin/scrape: scrolling to load lazy experience rows…')
+  const itemSelector = '[componentkey^="entity-collection-item"]'
+  const n = await scrollUntilStable(page, itemSelector)
+  console.log('linkedin/scrape: entity-collection-item count (after scroll):', n)
+
+  const fragment = await section.evaluate((el) => el.outerHTML)
+  const wrapped = `<!DOCTYPE html>
+<html lang="nl">
+<head><meta charset="utf-8"/><title>LinkedIn experience (captured)</title></head>
+<body>
+${fragment}
+</body>
+</html>
+`
+  writeFileSync(outHtml, wrapped, 'utf8')
+  console.log('linkedin/scrape: wrote', outHtml)
+
+  const skillPayload = {
+    generatedAt: new Date().toISOString(),
+    sourceUrl: EXPERIENCE_URL,
+    positions: {},
+  }
+
+  if (!noSkills) {
+    const hrefs = await page.$$eval(
+      'a[href*="/overlay/"][href*="/skill-associations-details/"]',
+      (as) => [...new Set(as.map((a) => a.getAttribute('href')).filter(Boolean))],
+    )
+
+    const idRe = /\/overlay\/(\d+)\/skill-associations-details/
+    const urls = hrefs
+      .map((h) => {
+        const abs = h.startsWith('http') ? h : new URL(h, 'https://www.linkedin.com').href
+        const m = abs.match(idRe)
+        return m ? { positionId: m[1], url: abs } : null
+      })
+      .filter(Boolean)
+
+    console.log('linkedin/scrape: unique skill overlay URLs:', urls.length)
+
+    for (const { positionId, url } of urls) {
+      try {
+        const res = await page.request.get(url)
+        const status = res.status()
+        const body = await res.text()
+        const skills = parseSkillsFromOverlayHtml(body)
+        skillPayload.positions[positionId] = {
+          ok: status >= 200 && status < 400,
+          httpStatus: status,
+          sourceUrl: url,
+          skills,
+          skillCount: skills.length,
+        }
+        if (skills.length === 0) {
+          skillPayload.positions[positionId].note =
+            'No skills parsed from overlay HTML; LinkedIn markup may have changed. Inspect raw in browser.'
+        }
+      } catch (e) {
+        skillPayload.positions[positionId] = {
+          ok: false,
+          sourceUrl: url,
+          error: String(e?.message ?? e),
+        }
+      }
+    }
+
+    writeFileSync(outSkills, JSON.stringify(skillPayload, null, 2), 'utf8')
+    console.log('linkedin/scrape: wrote', outSkills)
+  } else {
+    console.log('linkedin/scrape: skipped skill overlays (--no-skills)')
+  }
+
+  if (browserFromCdp) {
+    await browserFromCdp.close()
+    console.log('linkedin/scrape: disconnected from Chrome (your browser stays open).')
+  } else {
+    await context.close()
+  }
+  console.log('linkedin/scrape: done. Next: npm run linkedin:xml')
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/scripts/linkedin/to-xml.mjs
+++ b/scripts/linkedin/to-xml.mjs
@@ -1,0 +1,416 @@
+/**
+ * Turn tmp/linkedin.html (+ optional tmp/linkedin.skills.json) into tmp/linkedin.xml
+ * and copy scripts/linkedin/schema.xsd to tmp/linkedin.xsd for local validation.
+ *
+ * Usage:
+ *   node scripts/linkedin/to-xml.mjs
+ *   node scripts/linkedin/to-xml.mjs --html path/to/save.html
+ */
+import { readFileSync, writeFileSync, copyFileSync, existsSync, mkdirSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { JSDOM } from 'jsdom'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+const tmpDir = join(repoRoot, 'tmp')
+const defaultHtml = join(tmpDir, 'linkedin.html')
+const defaultSkills = join(tmpDir, 'linkedin.skills.json')
+const outXml = join(tmpDir, 'linkedin.xml')
+const outXsd = join(tmpDir, 'linkedin.xsd')
+const masterXsd = join(__dirname, 'schema.xsd')
+
+const NS = 'https://pkuppens.github.io/ns/linkedin-experience'
+const PERIOD_RE =
+  /^\s*([a-zäöüë]{3,4}\.?)\s+(\d{4})\s+-\s+(heden|present|[a-zäöüë]{3,4}\.?\s+\d{4})\s+·\s+(.+)$/i
+
+const MONTH_MAP = {
+  jan: 1,
+  feb: 2,
+  mrt: 3,
+  mar: 3,
+  apr: 4,
+  mei: 5,
+  jun: 6,
+  jul: 7,
+  aug: 8,
+  sep: 9,
+  okt: 10,
+  nov: 11,
+  dec: 12,
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2)
+  let htmlPath = defaultHtml
+  let skillsPath = defaultSkills
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--html' && args[i + 1]) {
+      htmlPath = args[++i]
+    }
+    if (args[i] === '--skills' && args[i + 1]) {
+      skillsPath = args[++i]
+    }
+  }
+  return { htmlPath, skillsPath }
+}
+
+function toYearMonth(monthToken, yearStr) {
+  const key = monthToken.toLowerCase().replaceAll('.', '')
+  const m = MONTH_MAP[key]
+  if (!m) return null
+  const y = parseInt(yearStr, 10)
+  if (Number.isNaN(y)) return null
+  return `${y}-${String(m).padStart(2, '0')}`
+}
+
+function parsePeriodLine(line) {
+  const m = line.match(PERIOD_RE)
+  if (!m) return null
+  const start = toYearMonth(m[1], m[2])
+  const endRaw = m[3].trim()
+  const endLower = endRaw.toLowerCase()
+  const endCurrent = endLower === 'heden' || endLower === 'present'
+  let end = null
+  if (!endCurrent) {
+    const p = endRaw.match(/^([a-zäöüë]{3,4}\.?)\s+(\d{4})$/i)
+    end = p ? toYearMonth(p[1], p[2]) : null
+  }
+  const durRaw = m[4].trim()
+  return { start, end, endCurrent, durationRaw: durRaw, raw: line.trim() }
+}
+
+function parseDuration(durRaw) {
+  let years = 0
+  let months = 0
+  const jr = durRaw.match(/(\d+)\s+jr\b/i)
+  const mnd = durRaw.match(/(\d+)\s+mnd\b/i)
+  const maanden = durRaw.match(/(\d+)\s+maanden\b/i)
+  if (jr) years += parseInt(jr[1], 10)
+  if (mnd) months += parseInt(mnd[1], 10)
+  if (maanden) months += parseInt(maanden[1], 10)
+  return { years, months, raw: durRaw }
+}
+
+function escapeXml(s) {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/]]>/g, ']]]]><![CDATA[')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+function escapeAttr(s) {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;')
+}
+
+function cdata(s) {
+  if (!s) return ''
+  return `<![CDATA[${s.replace(/]]>/g, ']]]]><![CDATA[')}]]>`
+}
+
+function splitTasksAndDescription(body) {
+  const lines = body.split(/\r?\n/)
+  const tasks = []
+  const prose = []
+  for (const line of lines) {
+    const t = line.trim()
+    if (/^[\*•]\s+/.test(t) || /^\d+\.\s+/.test(t)) {
+      tasks.push(t.replace(/^[\*•]\s+/, '').replace(/^\d+\.\s+/, '').trim())
+    } else if (t.length > 0) {
+      prose.push(line)
+    }
+  }
+  const description = prose.join('\n').trim()
+  return { description, tasks }
+}
+
+function loadSkills(skillsPath) {
+  if (!existsSync(skillsPath)) return {}
+  try {
+    const j = JSON.parse(readFileSync(skillsPath, 'utf8'))
+    const map = {}
+    for (const [id, v] of Object.entries(j.positions ?? {})) {
+      if (v?.skills && Array.isArray(v.skills)) map[id] = v.skills
+    }
+    return map
+  } catch {
+    return {}
+  }
+}
+
+function extractFormId(el) {
+  const a = el.querySelector?.('a[href*="/details/experience/edit/forms/"]')
+  if (!a) return null
+  const href = a.getAttribute('href') ?? ''
+  const m = href.match(/\/forms\/(\d+)\//)
+  return m ? m[1] : null
+}
+
+function parseCompanyLine(text) {
+  if (text.includes(' · ')) {
+    const [a, b] = text.split(' · ').map((s) => s.trim())
+    return { company: a, employmentType: b }
+  }
+  return { company: text.trim(), employmentType: '' }
+}
+
+function buildPeriodXml(period) {
+  if (!period) {
+    return '<period><raw>unparsed</raw></period>'
+  }
+  const { start, end, endCurrent, durationRaw, raw } = period
+  const d = parseDuration(durationRaw)
+  const parts = ['<period>']
+  if (start) {
+    parts.push(`<startDate yearMonth="${escapeAttr(start)}"/>`)
+  }
+  if (endCurrent) {
+    parts.push('<endDate current="true"/>')
+  } else if (end) {
+    parts.push(`<endDate yearMonth="${escapeAttr(end)}"/>`)
+  }
+  const dy = d.years > 0 ? ` years="${d.years}"` : ''
+  const dm = d.months > 0 ? ` months="${d.months}"` : ''
+  const dr = d.raw ? ` raw="${escapeAttr(d.raw)}"` : ''
+  if (dy || dm || dr) {
+    parts.push(`<duration${dy}${dm}${dr}/>`)
+  }
+  if (raw) {
+    parts.push(`<raw>${escapeXml(raw)}</raw>`)
+  }
+  parts.push('</period>')
+  return parts.join('')
+}
+
+function skillsXml(id, skillsById, truncated) {
+  const list = id ? skillsById[id] : null
+  const parts = []
+  if (list?.length) {
+    parts.push('<skills>')
+    for (const s of list) {
+      parts.push(`<skill>${escapeXml(s)}</skill>`)
+    }
+    parts.push('</skills>')
+  }
+  if (truncated) {
+    parts.push(`<skillsTruncatedSummary>${escapeXml(truncated)}</skillsTruncatedSummary>`)
+  }
+  return parts.join('')
+}
+
+function getExpandableText(el) {
+  const box = el.querySelector?.('[data-testid="expandable-text-box"]')
+  return (box?.textContent ?? '').trim()
+}
+
+function getTruncatedSkillsLine(block) {
+  const a = block.querySelector('a[href*="/skill-associations-details/"]')
+  if (!a) return ''
+  return (a.textContent ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function parseSingleBlock(block, skillsById, componentKey) {
+  const id = extractFormId(block) ?? `noid-${componentKey.replace(/[^a-z0-9-]/gi, '')}`
+  const title = (block.querySelector('p[class*="_33517241"]')?.textContent ?? '').trim()
+  const ul = block.querySelector('ul')
+  const smallPs = [...block.querySelectorAll('p[class*="_51112094"]')]
+    .filter((p) => !ul || !ul.contains(p))
+    .map((p) => (p.textContent ?? '').replace(/\s+/g, ' ').trim())
+  let companyLine = ''
+  let periodLine = ''
+  let locLine = ''
+  let pi = -1
+  for (let i = 0; i < smallPs.length; i++) {
+    if (PERIOD_RE.test(smallPs[i])) {
+      pi = i
+      periodLine = smallPs[i]
+      companyLine = pi > 0 ? smallPs.slice(0, pi).join(' | ') : ''
+      locLine = smallPs[pi + 1] ?? ''
+      break
+    }
+  }
+  if (!periodLine && smallPs.length >= 2) {
+    companyLine = smallPs[0] ?? ''
+    periodLine = smallPs[1] ?? ''
+    locLine = smallPs[2] ?? ''
+  }
+  const { company, employmentType } = parseCompanyLine(companyLine)
+  const period = periodLine ? parsePeriodLine(periodLine) : null
+  let location = locLine
+  let workMode = ''
+  if (location.includes(' · ')) {
+    const [a, b] = location.split(' · ').map((s) => s.trim())
+    location = a
+    workMode = b
+  }
+  const body = getExpandableText(block)
+  const { description, tasks } = splitTasksAndDescription(body)
+  const trunc = getTruncatedSkillsLine(block)
+
+  const parts = [
+    `<experience id="${escapeXml(id)}" linkedinComponentKey="${escapeXml(componentKey)}">`,
+    `<tagline>${escapeXml(title)}</tagline>`,
+    `<company>${escapeXml(company)}</company>`,
+  ]
+  if (employmentType) {
+    parts.push(`<employmentType>${escapeXml(employmentType)}</employmentType>`)
+  }
+  parts.push(buildPeriodXml(period))
+  if (location) {
+    parts.push(`<location>${escapeXml(location)}</location>`)
+  }
+  if (workMode) {
+    parts.push(`<workMode>${escapeXml(workMode)}</workMode>`)
+  }
+  if (description) {
+    parts.push(`<description>${cdata(description)}</description>`)
+  }
+  if (tasks.length) {
+    parts.push('<tasks>')
+    for (const t of tasks) {
+      parts.push(`<task>${escapeXml(t)}</task>`)
+    }
+    parts.push('</tasks>')
+  }
+  parts.push(skillsXml(id, skillsById, trunc))
+  parts.push('</experience>')
+  return parts.join('')
+}
+
+function parseGroupBlock(block, skillsById, componentKey) {
+  const ul =
+    block.querySelector('ul[class*="a8fd929c"]') ??
+    [...block.querySelectorAll('ul')].find((u) => u.querySelector('li'))
+  const lis = ul ? [...ul.querySelectorAll(':scope > li')] : []
+  if (lis.length === 0) {
+    return parseSingleBlock(block, skillsById, componentKey)
+  }
+
+  const titleCompany = (block.querySelector('p[class*="_33517241"]')?.textContent ?? '').trim()
+  const smallPs = [...block.querySelectorAll('p[class*="_51112094"]')]
+    .filter((p) => !ul || !ul.contains(p))
+    .map((p) => (p.textContent ?? '').replace(/\s+/g, ' ').trim())
+
+  const groupMeta = smallPs[0] ?? ''
+  const location = smallPs[1] ?? ''
+
+  let employmentType = ''
+  let totalDurationText = ''
+  if (groupMeta.includes(' · ')) {
+    const bits = groupMeta.split(' · ').map((s) => s.trim())
+    employmentType = bits[0] ?? ''
+    totalDurationText = bits.slice(1).join(' · ')
+  } else {
+    employmentType = groupMeta
+  }
+
+  const parts = [
+    `<experienceGroup linkedinComponentKey="${escapeXml(componentKey)}">`,
+    `<company>${escapeXml(titleCompany)}</company>`,
+    '<groupSummary>',
+  ]
+  if (employmentType) {
+    parts.push(`<employmentType>${escapeXml(employmentType)}</employmentType>`)
+  }
+  if (totalDurationText) {
+    parts.push(`<totalDurationText>${escapeXml(totalDurationText)}</totalDurationText>`)
+  }
+  parts.push('</groupSummary>')
+  if (location && !PERIOD_RE.test(location)) {
+    parts.push(`<location>${escapeXml(location)}</location>`)
+  }
+
+  for (const li of lis) {
+    const id = extractFormId(li) ?? `noid-li-${componentKey}`
+    const tagline = (li.querySelector('p[class*="_33517241"]')?.textContent ?? '').trim()
+    const dateLine = (
+      li.querySelector('p[class*="_51112094"][class*="a219e9ac"]') ??
+      [...li.querySelectorAll('p[class*="_51112094"]')].find((p) => PERIOD_RE.test(p.textContent ?? ''))
+    )?.textContent
+    const period = dateLine ? parsePeriodLine(dateLine.replace(/\s+/g, ' ').trim()) : null
+    const body = getExpandableText(li)
+    const { description, tasks } = splitTasksAndDescription(body)
+    const trunc = getTruncatedSkillsLine(li)
+
+    parts.push(`<experience id="${escapeXml(id)}">`)
+    parts.push(`<tagline>${escapeXml(tagline)}</tagline>`)
+    parts.push(buildPeriodXml(period))
+    if (description) {
+      parts.push(`<description>${cdata(description)}</description>`)
+    }
+    if (tasks.length) {
+      parts.push('<tasks>')
+      for (const t of tasks) {
+        parts.push(`<task>${escapeXml(t)}</task>`)
+      }
+      parts.push('</tasks>')
+    }
+    parts.push(skillsXml(id, skillsById, trunc))
+    parts.push('</experience>')
+  }
+  parts.push('</experienceGroup>')
+  return parts.join('')
+}
+
+function main() {
+  const { htmlPath, skillsPath } = parseArgs(process.argv)
+  mkdirSync(tmpDir, { recursive: true })
+
+  if (!existsSync(htmlPath)) {
+    console.error('linkedin/to-xml: HTML not found:', htmlPath)
+    console.error('Run: npm run linkedin:scrape')
+    process.exit(1)
+  }
+  if (!existsSync(masterXsd)) {
+    console.error('linkedin/to-xml: schema missing:', masterXsd)
+    process.exit(1)
+  }
+
+  copyFileSync(masterXsd, outXsd)
+
+  const html = readFileSync(htmlPath, 'utf8')
+  const dom = new JSDOM(html)
+  const doc = dom.window.document
+  const skillsById = loadSkills(skillsPath)
+
+  const section =
+    doc.querySelector('[data-testid^="profile_ExperienceDetailsSection"]') ?? doc.body
+  const items = [...section.querySelectorAll('[componentkey^="entity-collection-item"]')]
+
+  const metaParts = [
+    '<meta',
+    ` sourceUrl="https://www.linkedin.com/in/pieterkuppens/details/experience/"`,
+    ` scrapedAt="${new Date().toISOString()}"`,
+    ` locale="nl"`,
+    '/>',
+  ]
+
+  const bodyParts = []
+  for (const item of items) {
+    const key = item.getAttribute('componentkey') ?? ''
+    const ul =
+      item.querySelector('ul[class*="a8fd929c"]') ??
+      [...item.querySelectorAll(':scope ul')].find((u) => u.querySelector('li'))
+    if (ul && ul.querySelectorAll(':scope > li').length > 0) {
+      bodyParts.push(parseGroupBlock(item, skillsById, key))
+    } else {
+      bodyParts.push(parseSingleBlock(item, skillsById, key))
+    }
+  }
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<experiences xmlns="${NS}"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="${NS} linkedin.xsd">
+  ${metaParts.join('')}
+  ${bodyParts.join('\n  ')}
+</experiences>
+`
+
+  writeFileSync(outXml, xml, 'utf8')
+  console.log('linkedin/to-xml: wrote', outXml)
+  console.log('linkedin/to-xml: copied schema to', outXsd)
+}
+
+main()


### PR DESCRIPTION
Merges the LinkedIn Experience tooling from #41 (Playwright CDP scrape, `to-xml`, XSD, Windows helpers) and adds **explicit pivot documentation**: reliable live scraping of linkedin.com is **not** the maintenance strategy going forward.

**What landed earlier on this branch**
- Scrapers, `linkedin:xml`, and [`scripts/linkedin/schema.xsd`](scripts/linkedin/schema.xsd) for structured experience-shaped XML.

**This PR adds**
- [`scripts/linkedin/README.md`](scripts/linkedin/README.md) — status, target `data/linkedin/<slug>.xml`, legacy scrape note, tracking link to [#42](https://github.com/pkuppens/pkuppens.github.io/issues/42).
- Short **Status** note in [`scrape.mjs`](scripts/linkedin/scrape.mjs) and clarified schema comment.
- Root [`README.md`](README.md) pointer under Architecture.

[#42](https://github.com/pkuppens/pkuppens.github.io/issues/42) tracks the web/AI-assisted editor and committed profile mirror.

Ref: #41. Does **not** close #41 — that issue will be closed separately as **not planned**.
