### PR TITLE
#23: SEO and share preview metadata with automated checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Validate site metadata and assets
+        run: npm run validate:site-metadata
+
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm run build     # production build
 The same checks that run in CI (typecheck, tests, build) can be run locally before committing:
 
 ```bash
-npm run typecheck && npm test && npm run build
+npm run typecheck && npm test && npm run build && npm run validate:site-metadata
 ```
 
 To enforce this automatically on every commit, add a pre-commit hook (e.g. using [Husky](https://typicode.github.io/husky/)):

--- a/e2e/site-health.spec.ts
+++ b/e2e/site-health.spec.ts
@@ -1,22 +1,36 @@
 import { test, expect } from '@playwright/test'
 
 const LIVE_URL = 'https://pkuppens.github.io/'
+const PAGE_TITLE = 'Pieter Kuppens | Software, Data and AI Engineer'
+const META_DESCRIPTION =
+  'Software, data, and AI engineer with 30+ years in healthcare, finance, and high-tech. Experience in Python, C#/.NET, C/C++, SQL, cloud, GenAI/RAG, and non-LLM AI.'
+const CANONICAL_URL = 'https://pkuppens.github.io/'
 
 test('live site renders content and nav works', async ({ page, request }) => {
   // Fast HTML shell sanity check: confirms we get the expected document, not an error page.
   const htmlResponse = await request.get(LIVE_URL)
   expect(htmlResponse.ok(), 'Expected a 2xx response for the home page HTML').toBe(true)
   const html = await htmlResponse.text()
-  expect(html, 'Expected the HTML to contain the correct <title>').toContain(
-    '<title>Pieter Kuppens | Software, Data and AI Engineer</title>',
-  )
+  expect(html, 'Expected the HTML to contain the correct <title>').toContain(`<title>${PAGE_TITLE}</title>`)
+  expect(html, 'Expected meta description').toContain(`content="${META_DESCRIPTION}"`)
+  expect(html, 'Expected og:url').toContain(`property="og:url" content="${CANONICAL_URL}"`)
+  expect(html, 'Expected og:title').toContain(`property="og:title" content="${PAGE_TITLE}"`)
+  expect(html, 'Expected twitter:card').toContain('name="twitter:card" content="summary"')
   expect(html, 'Expected the HTML shell to contain #root').toContain('id="root"')
+
+  const faviconResponse = await request.get(new URL('/favicon.svg', LIVE_URL).href)
+  expect(faviconResponse.ok(), 'Expected favicon.svg to return 2xx').toBe(true)
+  const faviconType = faviconResponse.headers()['content-type'] ?? ''
+  expect(
+    faviconType.includes('image') || faviconType.includes('svg'),
+    `Expected image/svg content-type, got ${faviconType}`,
+  ).toBe(true)
 
   const response = await page.goto(LIVE_URL, { waitUntil: 'domcontentloaded' })
   expect(response, 'Expected a response for the home page').not.toBeNull()
   expect(response!.ok(), 'Expected a 2xx response for the home page').toBe(true)
 
-  await expect(page).toHaveTitle('Pieter Kuppens | Software, Data and AI Engineer')
+  await expect(page).toHaveTitle(PAGE_TITLE)
 
   // Header brand should be visible (signals React rendered and layout mounted)
   await expect(page.getByRole('link', { name: /Pieter Kuppens/i })).toBeVisible()

--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Software, data, and AI engineer with 30+ years in healthcare, finance, and high-tech. Experience in Python, C#/.NET, C/C++, SQL, cloud, GenAI/RAG, and non-LLM AI." />
+    <meta property="og:title" content="Pieter Kuppens | Software, Data and AI Engineer" />
+    <meta property="og:description" content="Software, data, and AI engineer with 30+ years in healthcare, finance, and high-tech. Experience in Python, C#/.NET, C/C++, SQL, cloud, GenAI/RAG, and non-LLM AI." />
+    <meta property="og:url" content="https://pkuppens.github.io/" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Pieter Kuppens | Software, Data and AI Engineer" />
+    <meta name="twitter:description" content="Software, data, and AI engineer with 30+ years in healthcare, finance, and high-tech. Experience in Python, C#/.NET, C/C++, SQL, cloud, GenAI/RAG, and non-LLM AI." />
     <title>Pieter Kuppens | Software, Data and AI Engineer</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build && node scripts/copy-github-pages-spa-fallback.mjs",
+    "validate:site-metadata": "node scripts/validate-site-metadata.mjs",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/validate-site-metadata.mjs
+++ b/scripts/validate-site-metadata.mjs
@@ -1,0 +1,111 @@
+/**
+ * Validate built site metadata and static assets in dist/ after `npm run build`.
+ *
+ * Usage:
+ *   npm run validate:site-metadata
+ *
+ * Exit codes:
+ *   0: valid
+ *   1: invalid
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { JSDOM } from 'jsdom'
+
+const CANONICAL_URL = 'https://pkuppens.github.io/'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const distDir = join(here, '..', 'dist')
+const indexPath = join(distDir, 'index.html')
+
+function fail(message) {
+  console.error('validate-site-metadata:', message)
+  process.exit(1)
+}
+
+function requireNonEmpty(value, label) {
+  if (!value?.trim()) {
+    fail(`Missing or empty ${label}`)
+  }
+  return value.trim()
+}
+
+function metaContent(doc, selector) {
+  const el = doc.querySelector(selector)
+  return (el?.getAttribute('content') ?? '').trim()
+}
+
+function resolveDistPath(href) {
+  if (!href || href.startsWith('http://') || href.startsWith('https://') || href.startsWith('data:')) {
+    return null
+  }
+  const normalized = href.replace(/^\//, '')
+  return join(distDir, normalized)
+}
+
+function assertAssetExists(href, label) {
+  const path = resolveDistPath(href)
+  if (!path) {
+    fail(`${label}: unsupported href "${href}"`)
+  }
+  if (!existsSync(path)) {
+    fail(`${label}: file not found at dist/${href.replace(/^\//, '')}`)
+  }
+}
+
+function validate() {
+  if (!existsSync(indexPath)) {
+    fail('dist/index.html missing; run npm run build first')
+  }
+
+  const html = readFileSync(indexPath, 'utf8')
+  const doc = new JSDOM(html).window.document
+
+  const title = requireNonEmpty(doc.querySelector('title')?.textContent, '<title>')
+  const description = requireNonEmpty(metaContent(doc, 'meta[name="description"]'), 'meta[name=description]')
+  const ogTitle = requireNonEmpty(metaContent(doc, 'meta[property="og:title"]'), 'og:title')
+  const ogDescription = requireNonEmpty(metaContent(doc, 'meta[property="og:description"]'), 'og:description')
+  const ogUrl = requireNonEmpty(metaContent(doc, 'meta[property="og:url"]'), 'og:url')
+  const ogType = requireNonEmpty(metaContent(doc, 'meta[property="og:type"]'), 'og:type')
+  const twitterCard = requireNonEmpty(metaContent(doc, 'meta[name="twitter:card"]'), 'twitter:card')
+  const twitterTitle = requireNonEmpty(metaContent(doc, 'meta[name="twitter:title"]'), 'twitter:title')
+  const twitterDescription = requireNonEmpty(
+    metaContent(doc, 'meta[name="twitter:description"]'),
+    'twitter:description',
+  )
+
+  if (ogUrl !== CANONICAL_URL) {
+    fail(`og:url must be ${CANONICAL_URL}, got "${ogUrl}"`)
+  }
+
+  if (ogTitle !== title) {
+    fail('og:title must match <title>')
+  }
+  if (twitterTitle !== title) {
+    fail('twitter:title must match <title>')
+  }
+  if (ogDescription !== description) {
+    fail('og:description must match meta[name=description]')
+  }
+  if (twitterDescription !== description) {
+    fail('twitter:description must match meta[name=description]')
+  }
+
+  const faviconLink = doc.querySelector('link[rel="icon"]')
+  const faviconHref = requireNonEmpty(faviconLink?.getAttribute('href'), 'link[rel=icon] href')
+  assertAssetExists(faviconHref, 'favicon')
+
+  const ogImage = metaContent(doc, 'meta[property="og:image"]')
+  if (ogImage) {
+    assertAssetExists(ogImage, 'og:image')
+  }
+
+  console.log('validate-site-metadata: OK', indexPath)
+}
+
+try {
+  validate()
+} catch (err) {
+  fail(err instanceof Error ? err.message : String(err))
+}


### PR DESCRIPTION
## Summary

- Add Open Graph and Twitter Card meta tags to `index.html` using current homepage positioning (`og:url` = `https://pkuppens.github.io/`; no `og:image` yet).
- Add `scripts/validate-site-metadata.mjs` and run it in CI after every build (favicon path, required tags, canonical URL, title/description consistency).
- Extend live site-health Playwright checks for OG/Twitter tags and `favicon.svg` availability.

**Part of #23** — does **not** close the issue. This PR delivers Step 1 (shell + automated checks) against today's copy.

## Follow-up before closing #23

Repeat or extend when positioning stabilizes:

- [ ] After **#17** (home) and **#18** (profile) land: align `<title>`, `meta description`, and OG/Twitter strings with final hero/bio copy.
- [ ] Optional: add `og:image` under `public/` when a share card asset exists.
- [ ] Re-run manual share preview check (Facebook Sharing Debugger) after copy change.

Alternatively, close #23 when a dedicated follow-up issue is filed for the copy refresh and this issue's acceptance criteria are split explicitly.

## Test plan

- [x] `npm run typecheck && npm test && npm run build && npm run validate:site-metadata`
- [ ] CI Deploy workflow passes on this PR
- [ ] After merge: site-health workflow passes on production
- [ ] Optional: [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) for share preview
