### PR TITLE
feat: deepen evaluator architecture and weighted commute scoring

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,36 @@
+# Domain context — pkuppens.github.io
+
+Vocabulary for architecture reviews and implementation. Use these terms consistently.
+
+## Core concepts
+
+**Profile**
+Pieter's professional identity: work preferences, experience timeline, and technology stack. Canonical data lives in `src/domain/profile/`. The Profile page and Opportunity Evaluator both read from this module.
+
+**Opportunity**
+A potential assignment described by the visitor (title, domain, rate, commute, hybrid days, duration, technologies). Represented as `OpportunityInput`.
+
+**Evaluation**
+The scored result of comparing one Opportunity against Profile preferences: total score, per-criterion breakdown, fit level, and recommendation text.
+
+**Criterion**
+One weighted dimension of an Evaluation (domain fit, hourly rate, hours per week, commute, hybrid arrangement, contract duration, technology fit). Each criterion is a pure `evaluate` function in `criteria.ts`. Commute logic lives in `commuteScore.ts` and weights degradation by √(onsite days per week).
+
+**Evaluator session**
+Browser-local state for the evaluator tool: saved opportunity input, optionally adjusted preferences, and the last Evaluation result. Orchestrated by `evaluatorSession.ts` / `useEvaluatorSession`.
+
+**Score band**
+A labelled range for a 0–100 score (excellent / good / fair / poor) with shared thresholds for overall results and per-criterion bars. Defined in `scoreBands.ts`.
+
+## Persistence
+
+**Storage keys**
+All `localStorage` access uses the `pkuppens_` prefix via `src/infrastructure/storage.ts`. Keys are listed in `storageKeys.ts` (evaluator input, evaluator preferences, theme).
+
+**Visitor preference overrides**
+Visitors may edit scoring preferences in the UI; those overrides are stored per browser. The versioned **Profile** in the repo remains the default when storage is empty. See ADR 003.
+
+## Out of scope (parked)
+
+**LinkedIn experience mirror**
+`data/linkedin/` and `scripts/linkedin/` are a future export path. Experience content is maintained in the Profile module until XML export is automated.

--- a/docs/adr/002-pure-functions-scoring.md
+++ b/docs/adr/002-pure-functions-scoring.md
@@ -11,11 +11,17 @@ The Opportunity Evaluator scores assignments across multiple criteria (domain fi
 - Easy to extend with new criteria or adjusted weights
 - Deterministic and transparent so scores can be explained to users
 
-**Example — commute scoring:**
-The total effective commute is calculated as `commuteMinutes × (onsiteDaysPerWeek + 1)` (round trip × frequency). This combined score is then evaluated as:
-- 0 minutes on-site → 100% (fully remote is the best case)
-- ≤ configured max commute minutes → interpolated linearly from 100% down to ~50%
-- Exceeding max commute → score drops steeply toward 0%
+**Example — commute scoring (`commuteScore.ts`):**
+Uses **one-way** `commuteMinutes` and `hybridDaysOnsite` (onsite days per week):
+- **0 onsite days** (fully remote) → 100%, commute ignored
+- **≥ 1 onsite day**: degradation from 100, then `score = 100 - degradation × sqrt(onsite days)` (clamped to -100)
+  - ≤ 10 min/day → no degradation
+  - 10–60 min → linear degradation 0→100%
+  - 60–90 min → +0→60 penalty on top (max degradation 160 before weighting)
+- Example: 60 min, 1 onsite day → 0%; 60 min, 4 onsite days → -100%
+
+**Example — hybrid scoring:**
+Onsite days per week (`hybridDaysOnsite`) are compared to `maxOnsiteDaysPerWeek`; excess days reduce the score.
 
 Each criterion returns a raw score (0–100) that is multiplied by its configured weight, then normalised against the sum of all weights to produce a weighted contribution to the final 0–100 score.
 

--- a/docs/adr/003-localstorage-persistence.md
+++ b/docs/adr/003-localstorage-persistence.md
@@ -24,6 +24,7 @@ Use `localStorage` via a thin infrastructure abstraction (`src/infrastructure/st
 - Sufficient for the intended per-browser use case
 
 ## Consequences
+- **Visitor preference sandbox**: The evaluator UI allows editing the full `ProfilePreferences` object; overrides are stored per browser under `evaluator_preferences`. Repo defaults in `src/domain/profile/` apply when storage is empty. This is intentional so recruiters can try “what-if” weights without a backend.
 - **Single-user per browser profile**: `localStorage` is scoped to the browser origin per browser profile. Each visitor — whether a recruiter evaluating a specific role, or Pieter himself — has their own isolated storage. A recruiter on their own PC starts with a clean state, independently of any other user on any other device. This is intentional.
 - Data is device-local and not synced across devices or browser profiles
 - Not suitable for shared or multi-user storage scenarios

--- a/docs/arc42/architecture.md
+++ b/docs/arc42/architecture.md
@@ -35,13 +35,16 @@ Single-page application built with React + TypeScript + Vite.
 src/
 ├── components/layout/   – Header, Footer, Layout (shell)
 ├── pages/               – Route-level page components
-│   └── evaluator/       – Opportunity Evaluator UI
+│   └── evaluator/       – Opportunity Evaluator UI + useEvaluatorSession
+├── domain/profile/      – Canonical Profile data (CV + evaluator defaults)
 ├── domain/evaluator/    – Pure scoring logic (no React)
 │   ├── types.ts         – Domain types
 │   ├── criteria.ts      – Criterion definitions + evaluation functions
 │   ├── scoring.ts       – Score aggregation engine
-│   └── defaultPreferences.ts
-└── infrastructure/      – Storage abstraction (localStorage)
+│   ├── scoreBands.ts    – Shared score thresholds and presentation
+│   ├── evaluatorSession.ts – Load/save/evaluate session (no React)
+│   └── defaultPreferences.ts – Re-exports profile scoring preferences
+└── infrastructure/      – Storage, theme, storage key registry
 ```
 
 ## 6. Runtime View
@@ -65,9 +68,9 @@ src/
 - Weekly **Dependabot** version updates and a scheduled **`npm audit`** workflow support dependency hygiene (see `.github/dependabot.yml` and `.github/workflows/security-audit.yml`).
 
 ### Testing Strategy
-- Unit tests: pure scoring functions (Vitest)
+- Unit tests: criteria, scoring, profile consistency, evaluator session, storage (Vitest)
 - Component tests: React Testing Library
-- E2E tests: Playwright (future)
+- E2E tests: Playwright site-health smoke (`e2e/site-health.spec.ts`)
 
 ### State Management
 - Local component state (useState) for UI

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,17 +1,15 @@
 import { NavLink } from 'react-router-dom'
 import { useEffect, useState } from 'react'
+import {
+  applyThemeToDocument,
+  saveTheme,
+  type Theme,
+} from '../../infrastructure/themeStorage'
 import styles from './Header.module.css'
-
-type Theme = 'light' | 'dark'
 
 function getCurrentTheme(): Theme {
   const t = document.documentElement.dataset.theme
   return t === 'dark' ? 'dark' : 'light'
-}
-
-function setTheme(theme: Theme) {
-  document.documentElement.dataset.theme = theme
-  localStorage.setItem('theme', theme)
 }
 
 export default function Header() {
@@ -22,8 +20,9 @@ export default function Header() {
   }, [])
 
   function onToggleTheme() {
-    const next = theme === 'dark' ? 'light' : 'dark'
-    setTheme(next)
+    const next: Theme = theme === 'dark' ? 'light' : 'dark'
+    applyThemeToDocument(next)
+    saveTheme(next)
     setThemeState(next)
   }
 

--- a/src/domain/evaluator/__tests__/commuteScore.test.ts
+++ b/src/domain/evaluator/__tests__/commuteScore.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { commuteDegradation, scoreCommute } from '../commuteScore'
+
+describe('commuteDegradation', () => {
+  it('returns 0 up to 10 minutes per day', () => {
+    expect(commuteDegradation(0)).toBe(0)
+    expect(commuteDegradation(10)).toBe(0)
+  })
+
+  it('degrades linearly from 10 to 60 minutes', () => {
+    expect(commuteDegradation(35)).toBe(50)
+    expect(commuteDegradation(60)).toBe(100)
+  })
+
+  it('adds up to 60 penalty points from 60 to 90 minutes', () => {
+    expect(commuteDegradation(75)).toBe(130)
+    expect(commuteDegradation(90)).toBe(160)
+  })
+})
+
+describe('scoreCommute', () => {
+  it('returns 100 for fully remote (0 onsite days)', () => {
+    expect(scoreCommute(120, 0)).toBe(100)
+  })
+
+  it('penalises full onsite with a long commute below zero', () => {
+    expect(scoreCommute(90, 5)).toBeLessThan(0)
+  })
+
+  it('returns 100 for full onsite when commute is acceptable', () => {
+    expect(scoreCommute(10, 5)).toBe(100)
+  })
+
+  it('returns 100 when commute is within 10 minutes on hybrid days', () => {
+    expect(scoreCommute(10, 2)).toBe(100)
+  })
+
+  it('scores 0% for 60 minutes with 1 onsite day', () => {
+    expect(scoreCommute(60, 1)).toBe(0)
+  })
+
+  it('scores -100% for 60 minutes with 4 onsite days', () => {
+    expect(scoreCommute(60, 4)).toBe(-100)
+  })
+
+  it('scales penalty by sqrt(onsite days)', () => {
+    const oneDay = scoreCommute(45, 1)
+    const fourDays = scoreCommute(45, 4)
+    expect(fourDays).toBeLessThan(oneDay)
+    expect(oneDay - fourDays).toBeGreaterThan(0)
+  })
+})

--- a/src/domain/evaluator/__tests__/criteria.test.ts
+++ b/src/domain/evaluator/__tests__/criteria.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import { CRITERIA } from '../criteria'
+import { DEFAULT_PREFERENCES } from '../defaultPreferences'
+import type { OpportunityInput, ProfilePreferences } from '../types'
+
+const baseInput: OpportunityInput = {
+  title: 'Test',
+  domain: 'Finance',
+  hoursPerWeek: 40,
+  hourlyRate: 120,
+  commuteMinutes: 30,
+  hybridDaysOnsite: 2,
+  durationMonths: 6,
+  technologies: ['Python'],
+  notes: '',
+}
+
+function scoreCriterion(
+  id: string,
+  input: OpportunityInput,
+  prefs: ProfilePreferences = DEFAULT_PREFERENCES,
+): number {
+  const criterion = CRITERIA.find(c => c.id === id)
+  if (!criterion) throw new Error(`unknown criterion: ${id}`)
+  return criterion.evaluate(input, prefs)
+}
+
+describe('criteria', () => {
+  describe('domain', () => {
+    it('returns 100 when domain matches a preferred domain', () => {
+      expect(scoreCriterion('domain', { ...baseInput, domain: 'Healthcare AI' })).toBe(100)
+    })
+
+    it('returns 40 when domain does not match', () => {
+      expect(scoreCriterion('domain', { ...baseInput, domain: 'Construction' })).toBe(40)
+    })
+
+    it('returns 50 when domain is empty', () => {
+      expect(scoreCriterion('domain', { ...baseInput, domain: '' })).toBe(50)
+    })
+  })
+
+  describe('rate', () => {
+    it('returns 100 at or above target hourly rate', () => {
+      expect(scoreCriterion('rate', { ...baseInput, hourlyRate: 140 })).toBe(100)
+      expect(scoreCriterion('rate', { ...baseInput, hourlyRate: 150 })).toBe(100)
+    })
+
+    it('returns 0 below minimum hourly rate', () => {
+      expect(scoreCriterion('rate', { ...baseInput, hourlyRate: 99 })).toBe(0)
+    })
+  })
+
+  describe('hours', () => {
+    it('returns 100 within preferred hours band', () => {
+      expect(scoreCriterion('hours', { ...baseInput, hoursPerWeek: 36 })).toBe(100)
+    })
+
+    it('penalises hours below minimum', () => {
+      expect(scoreCriterion('hours', { ...baseInput, hoursPerWeek: 24 })).toBeLessThan(100)
+    })
+
+    it('penalises hours above maximum', () => {
+      expect(scoreCriterion('hours', { ...baseInput, hoursPerWeek: 48 })).toBeLessThan(100)
+    })
+  })
+
+  describe('commute', () => {
+    it('returns 100 for fully remote (0 onsite days)', () => {
+      expect(
+        scoreCriterion('commute', { ...baseInput, commuteMinutes: 90, hybridDaysOnsite: 0 }),
+      ).toBe(100)
+    })
+
+    it('penalises full onsite with a long commute below zero', () => {
+      expect(
+        scoreCriterion('commute', { ...baseInput, commuteMinutes: 90, hybridDaysOnsite: 5 }),
+      ).toBeLessThan(0)
+    })
+
+    it('returns 0 for 60 minutes with 1 onsite day', () => {
+      expect(
+        scoreCriterion('commute', { ...baseInput, commuteMinutes: 60, hybridDaysOnsite: 1 }),
+      ).toBe(0)
+    })
+
+    it('returns -100 for 60 minutes with 4 onsite days', () => {
+      expect(
+        scoreCriterion('commute', { ...baseInput, commuteMinutes: 60, hybridDaysOnsite: 4 }),
+      ).toBe(-100)
+    })
+  })
+
+  describe('hybrid', () => {
+    it('returns 100 when onsite days are within limit', () => {
+      expect(scoreCriterion('hybrid', { ...baseInput, hybridDaysOnsite: 2 })).toBe(100)
+    })
+
+    it('penalises excess onsite days', () => {
+      expect(scoreCriterion('hybrid', { ...baseInput, hybridDaysOnsite: 5 })).toBeLessThan(100)
+    })
+  })
+
+  describe('duration', () => {
+    it('returns 100 inside preferred duration range', () => {
+      expect(scoreCriterion('duration', { ...baseInput, durationMonths: 6 })).toBe(100)
+    })
+
+    it('penalises duration below minimum', () => {
+      expect(scoreCriterion('duration', { ...baseInput, durationMonths: 1 })).toBeLessThan(100)
+    })
+  })
+
+  describe('technology', () => {
+    it('returns 50 when no technologies listed', () => {
+      expect(scoreCriterion('technology', { ...baseInput, technologies: [] })).toBe(50)
+    })
+
+    it('returns 100 when all technologies match preferences', () => {
+      expect(
+        scoreCriterion('technology', { ...baseInput, technologies: ['Python', 'Azure'] }),
+      ).toBe(100)
+    })
+
+    it('returns 0 when no technologies match', () => {
+      expect(
+        scoreCriterion('technology', { ...baseInput, technologies: ['COBOL'] }),
+      ).toBe(0)
+    })
+  })
+})

--- a/src/domain/evaluator/__tests__/evaluatorSession.test.ts
+++ b/src/domain/evaluator/__tests__/evaluatorSession.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createDefaultOpportunityInput,
+  loadEvaluatorInput,
+  loadEvaluatorPreferences,
+  persistEvaluatorPreferences,
+  runEvaluation,
+} from '../evaluatorSession'
+import { DEFAULT_PREFERENCES } from '../defaultPreferences'
+import { STORAGE_KEYS } from '../../../infrastructure/storageKeys'
+
+describe('evaluatorSession', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('createDefaultOpportunityInput uses target hourly rate from preferences', () => {
+    const input = createDefaultOpportunityInput(DEFAULT_PREFERENCES)
+    expect(input.hourlyRate).toBe(DEFAULT_PREFERENCES.targetHourlyRate)
+  })
+
+  it('loadEvaluatorPreferences returns defaults when storage is empty', () => {
+    expect(loadEvaluatorPreferences()).toEqual(DEFAULT_PREFERENCES)
+  })
+
+  it('persists and reloads visitor preference overrides', () => {
+    const custom = { ...DEFAULT_PREFERENCES, targetHourlyRate: 120 }
+    persistEvaluatorPreferences(custom)
+    expect(loadEvaluatorPreferences()).toEqual(custom)
+  })
+
+  it('loadEvaluatorInput falls back to defaults when storage is empty', () => {
+    const input = loadEvaluatorInput()
+    expect(input.hourlyRate).toBe(DEFAULT_PREFERENCES.targetHourlyRate)
+  })
+
+  it('runEvaluation returns a score between 0 and 100', () => {
+    const input = createDefaultOpportunityInput()
+    const result = runEvaluation(
+      { ...input, domain: 'Finance', hourlyRate: 140, commuteMinutes: 0 },
+      DEFAULT_PREFERENCES,
+    )
+    expect(result.totalScore).toBeGreaterThanOrEqual(0)
+    expect(result.totalScore).toBeLessThanOrEqual(100)
+  })
+
+  it('uses namespaced storage keys', () => {
+    persistEvaluatorPreferences(DEFAULT_PREFERENCES)
+    expect(localStorage.getItem(`pkuppens_${STORAGE_KEYS.evaluatorPreferences}`)).not.toBeNull()
+  })
+})

--- a/src/domain/evaluator/commuteScore.ts
+++ b/src/domain/evaluator/commuteScore.ts
@@ -1,0 +1,57 @@
+/**
+ * Commute criterion scoring (0–100 raw score; may go negative before weighting).
+ *
+ * One-way `commuteMinutes` is compared to per-day thresholds. Degradation is
+ * multiplied by sqrt(onsite days per week) so more office days amplify the penalty.
+ */
+
+const ACCEPTABLE_MINUTES = 10
+const LINEAR_MAX_MINUTES = 60
+const PENALTY_MAX_MINUTES = 90
+const MAX_EXTRA_PENALTY = 60
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+/**
+ * Degradation points subtracted from 100 before onsite-day weighting.
+ * Up to 10 min/day: 0. Linear 10→60: 0→100. Extra 60→90: up to +60 penalty.
+ */
+export function commuteDegradation(commuteMinutes: number): number {
+  if (commuteMinutes <= ACCEPTABLE_MINUTES) return 0
+
+  if (commuteMinutes <= LINEAR_MAX_MINUTES) {
+    return ((commuteMinutes - ACCEPTABLE_MINUTES) / (LINEAR_MAX_MINUTES - ACCEPTABLE_MINUTES)) * 100
+  }
+
+  const linearDegradation = 100
+  if (commuteMinutes <= PENALTY_MAX_MINUTES) {
+    const extra =
+      ((commuteMinutes - LINEAR_MAX_MINUTES) / (PENALTY_MAX_MINUTES - LINEAR_MAX_MINUTES)) *
+      MAX_EXTRA_PENALTY
+    return linearDegradation + extra
+  }
+
+  return linearDegradation + MAX_EXTRA_PENALTY
+}
+
+/**
+ * Raw commute score for an opportunity.
+ *
+ * Args:
+ *   commuteMinutes: one-way commute duration in minutes (per office day).
+ *   hybridDaysOnsite: expected onsite days per week (0 = fully remote).
+ *
+ * Returns:
+ *   number: raw score from -100 to 100.
+ */
+export function scoreCommute(commuteMinutes: number, hybridDaysOnsite: number): number {
+  if (hybridDaysOnsite === 0) {
+    return 100
+  }
+
+  const degradation = commuteDegradation(commuteMinutes)
+  const weightedDegradation = degradation * Math.sqrt(Math.max(1, hybridDaysOnsite))
+  return clamp(100 - weightedDegradation, -100, 100)
+}

--- a/src/domain/evaluator/criteria.ts
+++ b/src/domain/evaluator/criteria.ts
@@ -1,3 +1,4 @@
+import { scoreCommute } from './commuteScore'
 import type { CriterionConfig, OpportunityInput, ProfilePreferences } from './types'
 
 function clamp(value: number, min: number, max: number): number {
@@ -53,12 +54,8 @@ export const CRITERIA: CriterionConfig[] = [
     id: 'commute',
     label: 'Commute',
     weight: 15,
-    evaluate(input: OpportunityInput, prefs: ProfilePreferences): number {
-      if (input.commuteMinutes === 0) return 100
-      if (input.commuteMinutes > prefs.maxCommuteMinutes) {
-        return clamp(100 - (input.commuteMinutes - prefs.maxCommuteMinutes) * 2, 0, 30)
-      }
-      return lerp(prefs.maxCommuteMinutes - input.commuteMinutes, 0, prefs.maxCommuteMinutes) * 0.5 + 50
+    evaluate(input: OpportunityInput, _prefs: ProfilePreferences): number {
+      return Math.round(scoreCommute(input.commuteMinutes, input.hybridDaysOnsite))
     },
   },
   {

--- a/src/domain/evaluator/defaultPreferences.ts
+++ b/src/domain/evaluator/defaultPreferences.ts
@@ -1,17 +1,4 @@
-import type { ProfilePreferences } from './types'
+import { PROFILE_EVALUATOR_PREFERENCES } from '../profile/profileData'
 
-export const DEFAULT_PREFERENCES: ProfilePreferences = {
-  preferredDomains: ['Finance', 'Healthcare', 'Logistics', 'Technology', 'AI', 'Data'],
-  minHoursPerWeek: 32,
-  maxHoursPerWeek: 40,
-  minHourlyRate: 75,
-  targetHourlyRate: 110,
-  maxCommuteMinutes: 60,
-  maxOnsiteDaysPerWeek: 3,
-  minDurationMonths: 3,
-  maxDurationMonths: 12,
-  preferredTechnologies: [
-    'Python', 'TypeScript', 'React', 'FastAPI', 'Azure',
-    'LangChain', 'OpenAI', 'Docker', 'SQL', 'AWS',
-  ],
-}
+/** Default scoring preferences for the Opportunity Evaluator (canonical Profile data). */
+export const DEFAULT_PREFERENCES = PROFILE_EVALUATOR_PREFERENCES

--- a/src/domain/evaluator/evaluatorSession.ts
+++ b/src/domain/evaluator/evaluatorSession.ts
@@ -1,0 +1,50 @@
+import { DEFAULT_PREFERENCES } from './defaultPreferences'
+import { CRITERIA } from './criteria'
+import { evaluateOpportunity } from './scoring'
+import type { EvaluationResult, OpportunityInput, ProfilePreferences } from './types'
+import { STORAGE_KEYS } from '../../infrastructure/storageKeys'
+import { loadFromStorage, saveToStorage } from '../../infrastructure/storage'
+
+export { STORAGE_KEYS as EVALUATOR_STORAGE_KEYS }
+
+export function createDefaultOpportunityInput(
+  prefs: ProfilePreferences = DEFAULT_PREFERENCES,
+): OpportunityInput {
+  return {
+    title: '',
+    domain: '',
+    hoursPerWeek: 40,
+    hourlyRate: prefs.targetHourlyRate,
+    commuteMinutes: 30,
+    hybridDaysOnsite: 2,
+    durationMonths: 6,
+    technologies: [],
+    notes: '',
+  }
+}
+
+export function loadEvaluatorPreferences(): ProfilePreferences {
+  return loadFromStorage(STORAGE_KEYS.evaluatorPreferences, DEFAULT_PREFERENCES)
+}
+
+export function loadEvaluatorInput(prefs?: ProfilePreferences): OpportunityInput {
+  return loadFromStorage(
+    STORAGE_KEYS.evaluatorLastInput,
+    createDefaultOpportunityInput(prefs ?? DEFAULT_PREFERENCES),
+  )
+}
+
+export function runEvaluation(
+  input: OpportunityInput,
+  prefs: ProfilePreferences,
+): EvaluationResult {
+  return evaluateOpportunity(input, prefs, CRITERIA)
+}
+
+export function persistEvaluatorInput(input: OpportunityInput): void {
+  saveToStorage(STORAGE_KEYS.evaluatorLastInput, input)
+}
+
+export function persistEvaluatorPreferences(prefs: ProfilePreferences): void {
+  saveToStorage(STORAGE_KEYS.evaluatorPreferences, prefs)
+}

--- a/src/domain/evaluator/scoreBands.ts
+++ b/src/domain/evaluator/scoreBands.ts
@@ -1,0 +1,31 @@
+import type { ScoreLevel } from './types'
+
+/** Shared thresholds (0–100) for overall Evaluation level and per-criterion bars. */
+export const SCORE_BAND_THRESHOLDS = {
+  excellent: 90,
+  good: 60,
+  fair: 40,
+} as const
+
+export function getScoreLevel(score: number): ScoreLevel {
+  if (score >= SCORE_BAND_THRESHOLDS.excellent) return 'excellent'
+  if (score >= SCORE_BAND_THRESHOLDS.good) return 'good'
+  if (score >= SCORE_BAND_THRESHOLDS.fair) return 'fair'
+  return 'poor'
+}
+
+export const LEVEL_PRESENTATION: Record<
+  ScoreLevel,
+  { label: string; color: string; bg: string }
+> = {
+  excellent: { label: 'Excellent fit', color: '#16a34a', bg: '#f0fdf4' },
+  good: { label: 'Good fit', color: '#2563eb', bg: '#eff6ff' },
+  fair: { label: 'Fair fit', color: '#d97706', bg: '#fffbeb' },
+  poor: { label: 'Poor fit', color: '#dc2626', bg: '#fef2f2' },
+}
+
+/** Colour for a raw criterion score bar (same bands as overall level). */
+export function getRawScoreColor(rawScore: number): string {
+  const level = getScoreLevel(rawScore)
+  return LEVEL_PRESENTATION[level].color
+}

--- a/src/domain/evaluator/scoring.ts
+++ b/src/domain/evaluator/scoring.ts
@@ -5,13 +5,9 @@ import type {
   ProfilePreferences,
   ScoreLevel,
 } from './types'
+import { getScoreLevel } from './scoreBands'
 
-export function getScoreLevel(score: number): ScoreLevel {
-  if (score >= 90) return 'excellent'
-  if (score >= 60) return 'good'
-  if (score >= 40) return 'fair'
-  return 'poor'
-}
+export { getScoreLevel } from './scoreBands'
 
 export function getRecommendation(_score: number, level: ScoreLevel): string {
   switch (level) {

--- a/src/domain/profile/__tests__/profileConsistency.test.ts
+++ b/src/domain/profile/__tests__/profileConsistency.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { DISPLAY_PREFERENCES, PROFILE_EVALUATOR_PREFERENCES } from '../profileData'
+import { DEFAULT_PREFERENCES } from '../../evaluator/defaultPreferences'
+
+describe('profile consistency', () => {
+  it('evaluator defaults re-export profile scoring preferences', () => {
+    expect(DEFAULT_PREFERENCES).toEqual(PROFILE_EVALUATOR_PREFERENCES)
+  })
+
+  it('displays rate range aligned with scoring minimum and target', () => {
+    const rateCard = DISPLAY_PREFERENCES.find(p => p.label === 'Rate range')
+    expect(rateCard?.value).toBe(
+      `€${PROFILE_EVALUATOR_PREFERENCES.minHourlyRate}–€${PROFILE_EVALUATOR_PREFERENCES.targetHourlyRate}/hour`,
+    )
+  })
+
+  it('displays contract duration aligned with scoring bounds', () => {
+    const durationCard = DISPLAY_PREFERENCES.find(p => p.label === 'Contract duration')
+    expect(durationCard?.value).toBe(
+      `${PROFILE_EVALUATOR_PREFERENCES.minDurationMonths}–${PROFILE_EVALUATOR_PREFERENCES.maxDurationMonths} months preferred`,
+    )
+  })
+})

--- a/src/domain/profile/index.ts
+++ b/src/domain/profile/index.ts
@@ -1,0 +1,7 @@
+export type { DisplayPreference, ExperienceEntry, TechStack } from './types'
+export {
+  DISPLAY_PREFERENCES,
+  EXPERIENCE,
+  PROFILE_EVALUATOR_PREFERENCES,
+  TECH_STACK,
+} from './profileData'

--- a/src/domain/profile/profileData.ts
+++ b/src/domain/profile/profileData.ts
@@ -1,0 +1,165 @@
+import type { ProfilePreferences } from '../evaluator/types'
+import type { DisplayPreference, ExperienceEntry, TechStack } from './types'
+
+/** Scoring preferences derived from the same facts shown on the Profile page. */
+export const PROFILE_EVALUATOR_PREFERENCES: ProfilePreferences = {
+  preferredDomains: ['Healthcare', 'Finance', 'High-Tech', 'Data', 'AI'],
+  minHoursPerWeek: 32,
+  maxHoursPerWeek: 40,
+  minHourlyRate: 100,
+  targetHourlyRate: 140,
+  maxCommuteMinutes: 60,
+  maxOnsiteDaysPerWeek: 3,
+  minDurationMonths: 3,
+  maxDurationMonths: 18,
+  preferredTechnologies: [
+    'Python', 'TypeScript', 'React', 'FastAPI', 'Azure',
+    'LangChain', 'OpenAI', 'Docker', 'SQL', 'AWS',
+  ],
+}
+
+function formatRateRange(prefs: ProfilePreferences): string {
+  return `€${prefs.minHourlyRate}–€${prefs.targetHourlyRate}/hour`
+}
+
+function formatDurationRange(prefs: ProfilePreferences): string {
+  return `${prefs.minDurationMonths}–${prefs.maxDurationMonths} months preferred`
+}
+
+/** Human-readable preference cards for the Profile page (generated from evaluator prefs). */
+export const DISPLAY_PREFERENCES: DisplayPreference[] = [
+  { label: 'Location', value: 'Netherlands (Den Bosch-Eindhoven), hybrid/remote' },
+  {
+    label: 'Preferred domains',
+    value: 'Healthcare, Finance, High-Tech, Data and AI',
+  },
+  { label: 'Rate range', value: formatRateRange(PROFILE_EVALUATOR_PREFERENCES) },
+  { label: 'Contract duration', value: formatDurationRange(PROFILE_EVALUATOR_PREFERENCES) },
+  {
+    label: 'Min. hours/week',
+    value: `${PROFILE_EVALUATOR_PREFERENCES.minHoursPerWeek} hours minimum`,
+  },
+  {
+    label: 'Travel',
+    value: 'Max 3-4 hour commute weekly, rest remote',
+  },
+]
+
+export const EXPERIENCE: ExperienceEntry[] = [
+  {
+    period: '2026 – Present',
+    role: 'Senior Consultant (Software, Data, and AI)',
+    company: 'Bright Cubes',
+    desc: 'Consulting on software, data, and AI assignments with focus on practical delivery and business value.',
+    tags: ['Software Engineering', 'Data', 'AI', 'Consulting'],
+  },
+  {
+    period: '2025',
+    role: 'Software-Data-AI Professional',
+    company: 'Angiogenesis Analytics',
+    desc: 'Software and data work in a medical equipment context, with focus on healthcare-oriented AI solutions.',
+    tags: ['Healthcare', 'AI', 'Python', 'Data'],
+  },
+  {
+    period: '2022 – 2025',
+    role: 'AI Transaction Monitoring Workflow Optimization',
+    company: 'Rent a Pin',
+    desc: 'Built and improved AI-supported transaction monitoring workflows in a financial services context.',
+    tags: ['AI', 'Finance', 'Workflow', 'Optimization'],
+  },
+  {
+    period: '2020 – 2021',
+    role: 'Software and Data Professional (Deep Learning)',
+    company: 'CART-Tech',
+    desc: 'Developed deep learning segmentation for medical imaging and supported migration to cloud scalability.',
+    tags: ['Deep Learning', 'Medical Imaging', 'Python', 'AWS'],
+  },
+  {
+    period: '2018 – 2020',
+    role: 'Software Architect and Coach',
+    company: 'Nemo Healthcare',
+    desc: 'Supported regulated software workflows and built Python solutions in healthcare environments.',
+    tags: ['ISO 13485', 'IEC 62304', 'Python', 'Coaching'],
+  },
+  {
+    period: 'Feb 2018 – Oct 2018',
+    role: 'Software en Data Professional',
+    company: 'Isatis Health',
+    desc: 'Short assignment in a healthcare context with a focus on practical software delivery and data-oriented work.',
+    tags: ['Healthcare', 'Software Engineering', 'Data'],
+  },
+  {
+    period: 'May 2013 – Jul 2018',
+    role: 'Senior Software Engineer (part-time)',
+    company: 'Ratho BV',
+    desc: 'Part-time side job focused on C/C++ and SQL-heavy engineering, mentoring, and delivery support.',
+    tags: ['C#', 'SQL', 'Mentoring', 'Part-time (5-10%)'],
+  },
+  {
+    period: 'Apr 2013 – Present',
+    role: 'Software en Data Professional (self-employed)',
+    company: 'pieterkuppens.net',
+    desc: 'Independent practice delivering software and data projects across healthcare, finance, and high-tech.',
+    tags: ['Freelance', 'Python', 'C#/.NET', 'C/C++', 'SQL'],
+  },
+  {
+    period: 'Dec 2012 – Apr 2013',
+    role: 'Technical Engineer',
+    company: 'Blueriq',
+    desc: 'Short assignment focusing on frontend-oriented engineering in a professional software environment.',
+    tags: ['Frontend', 'WPF', 'HTML/CSS'],
+  },
+  {
+    period: 'Jul 2012 – Nov 2012',
+    role: 'Technical Engineer',
+    company: 'ABN AMRO Bank',
+    desc: 'Engineering work in a banking environment with focus on secure enterprise delivery.',
+    tags: ['Security', 'Enterprise', 'C#/.NET', 'MSSQL'],
+  },
+  {
+    period: 'Apr 2012 – Jun 2012',
+    role: 'Security Specialist',
+    company: 'ABN AMRO Lease',
+    desc: 'Security-focused work including SMS 2FA and password policy improvements.',
+    tags: ['Security', '2FA', 'Policies'],
+  },
+  {
+    period: 'Apr 2012 – Apr 2013',
+    role: 'Technical Engineer',
+    company: 'Everest BV',
+    desc: 'Technical engineering role across a one-year period (overlapping with short assignments).',
+    tags: ['Engineering', 'Consulting'],
+  },
+  {
+    period: '2011 – 2012',
+    role: 'Software Designer',
+    company: 'Philips Healthcare',
+    desc: 'Contributed to medical software with 3D visualization support for ablation treatment use cases.',
+    tags: ['Healthcare', 'Scientific Software', 'C/C++', 'Visualization'],
+  },
+  {
+    period: '2010',
+    role: 'Software Engineer',
+    company: 'BOSOR',
+    desc: 'Contributed to frontend to planning software',
+    tags: ['Delphi', 'JavaScript'],
+  },
+  {
+    period: '1997 – 2009',
+    role: 'Software Designer',
+    company: 'ASML',
+    desc: 'Long-tenure high-tech engineering on complex software projects in large-scale semiconductor systems.',
+    tags: ['High-Tech', 'C/C++', 'Engineering', 'Long-term'],
+  },
+]
+
+export const TECH_STACK: TechStack = {
+  'Core Languages': ['Python', 'C#/.NET', 'C/C++', 'SQL', 'JavaScript'],
+  'Data and AI': [
+    'GenAI', 'LLM', 'RAG', 'AI-assisted development', 'Deep Learning', 'NLP Support',
+    'Transaction Monitoring AI', 'Data Pipelines',
+  ],
+  'Cloud and DevOps': ['Azure', 'AWS', 'CI/CD', 'Docker', 'Jira/Confluence/Bitbucket'],
+  'Security and Compliance': ['SMS 2FA', 'Password Policies', 'ISO 13485 Context', 'IEC 62304 Context'],
+  'Databases and Storage': ['MSSQL', 'SQLite', 'MySQL', 'PostgreSQL'],
+}

--- a/src/domain/profile/types.ts
+++ b/src/domain/profile/types.ts
@@ -1,0 +1,14 @@
+export interface ExperienceEntry {
+  period: string
+  role: string
+  company: string
+  desc: string
+  tags: string[]
+}
+
+export interface DisplayPreference {
+  label: string
+  value: string
+}
+
+export type TechStack = Record<string, string[]>

--- a/src/infrastructure/__tests__/themeStorage.test.ts
+++ b/src/infrastructure/__tests__/themeStorage.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { applyThemeToDocument, loadTheme, saveTheme } from '../themeStorage'
+import { LEGACY_THEME_KEY, STORAGE_KEYS } from '../storageKeys'
+
+describe('themeStorage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    delete document.documentElement.dataset.theme
+  })
+
+  it('defaults to dark when no theme is stored', () => {
+    expect(loadTheme()).toBe('dark')
+  })
+
+  it('saves and loads theme via namespaced storage', () => {
+    saveTheme('light')
+    expect(loadTheme()).toBe('light')
+    expect(localStorage.getItem(`pkuppens_${STORAGE_KEYS.theme}`)).toBe('"light"')
+  })
+
+  it('migrates legacy unprefixed theme key', () => {
+    localStorage.setItem(LEGACY_THEME_KEY, 'light')
+    expect(loadTheme()).toBe('light')
+    expect(localStorage.getItem(LEGACY_THEME_KEY)).toBeNull()
+    expect(localStorage.getItem(`pkuppens_${STORAGE_KEYS.theme}`)).toBe('"light"')
+  })
+
+  it('applyThemeToDocument sets dataset.theme', () => {
+    applyThemeToDocument('light')
+    expect(document.documentElement.dataset.theme).toBe('light')
+  })
+})

--- a/src/infrastructure/storageKeys.ts
+++ b/src/infrastructure/storageKeys.ts
@@ -1,0 +1,9 @@
+/** Registry of localStorage keys (prefix applied in storage.ts). */
+export const STORAGE_KEYS = {
+  theme: 'theme',
+  evaluatorPreferences: 'evaluator_preferences',
+  evaluatorLastInput: 'evaluator_last_input',
+} as const
+
+/** Legacy theme key before pkuppens_ prefix migration. */
+export const LEGACY_THEME_KEY = 'theme'

--- a/src/infrastructure/themeStorage.ts
+++ b/src/infrastructure/themeStorage.ts
@@ -1,0 +1,43 @@
+import { LEGACY_THEME_KEY, STORAGE_KEYS } from './storageKeys'
+import { loadFromStorage, saveToStorage } from './storage'
+
+export type Theme = 'light' | 'dark'
+
+const DEFAULT_THEME: Theme = 'dark'
+
+function readLegacyTheme(): Theme | null {
+  try {
+    const raw = localStorage.getItem(LEGACY_THEME_KEY)
+    if (raw === 'light' || raw === 'dark') return raw
+  } catch {
+    // ignore
+  }
+  return null
+}
+
+/** Load theme from storage, migrating legacy unprefixed key when present. */
+export function loadTheme(): Theme {
+  const stored = loadFromStorage<Theme | null>(STORAGE_KEYS.theme, null)
+  if (stored === 'light' || stored === 'dark') return stored
+
+  const legacy = readLegacyTheme()
+  if (legacy) {
+    saveToStorage(STORAGE_KEYS.theme, legacy)
+    try {
+      localStorage.removeItem(LEGACY_THEME_KEY)
+    } catch {
+      // ignore
+    }
+    return legacy
+  }
+
+  return DEFAULT_THEME
+}
+
+export function saveTheme(theme: Theme): void {
+  saveToStorage(STORAGE_KEYS.theme, theme)
+}
+
+export function applyThemeToDocument(theme: Theme): void {
+  document.documentElement.dataset.theme = theme
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,19 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import { applyThemeToDocument, loadTheme } from './infrastructure/themeStorage'
 import './index.css'
 
-function applyInitialTheme() {
-  const stored = localStorage.getItem('theme')
-  if (stored === 'light' || stored === 'dark') {
-    document.documentElement.dataset.theme = stored
-    return
-  }
-
-  document.documentElement.dataset.theme = 'dark'
-}
-
-applyInitialTheme()
+applyThemeToDocument(loadTheme())
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,129 +1,9 @@
+import {
+  DISPLAY_PREFERENCES,
+  EXPERIENCE,
+  TECH_STACK,
+} from '../domain/profile'
 import styles from './ProfilePage.module.css'
-
-const EXPERIENCE = [
-  {
-    period: '2026 – Present',
-    role: 'Senior Consultant (Software, Data, and AI)',
-    company: 'Bright Cubes',
-    desc: 'Consulting on software, data, and AI assignments with focus on practical delivery and business value.',
-    tags: ['Software Engineering', 'Data', 'AI', 'Consulting'],
-  },
-  {
-    period: '2025',
-    role: 'Software-Data-AI Professional',
-    company: 'Angiogenesis Analytics',
-    desc: 'Software and data work in a medical equipment context, with focus on healthcare-oriented AI solutions.',
-    tags: ['Healthcare', 'AI', 'Python', 'Data'],
-  },
-  {
-    period: '2022 – 2025',
-    role: 'AI Transaction Monitoring Workflow Optimization',
-    company: 'Rent a Pin',
-    desc: 'Built and improved AI-supported transaction monitoring workflows in a financial services context.',
-    tags: ['AI', 'Finance', 'Workflow', 'Optimization'],
-  },
-  {
-    period: '2020 – 2021',
-    role: 'Software and Data Professional (Deep Learning)',
-    company: 'CART-Tech',
-    desc: 'Developed deep learning segmentation for medical imaging and supported migration to cloud scalability.',
-    tags: ['Deep Learning', 'Medical Imaging', 'Python', 'AWS'],
-  },
-  {
-    period: '2018 – 2020',
-    role: 'Software Architect and Coach',
-    company: 'Nemo Healthcare',
-    desc: 'Supported regulated software workflows and built Python solutions in healthcare environments.',
-    tags: ['ISO 13485', 'IEC 62304', 'Python', 'Coaching'],
-  },
-  {
-    period: 'Feb 2018 – Oct 2018',
-    role: 'Software en Data Professional',
-    company: 'Isatis Health',
-    desc: 'Short assignment in a healthcare context with a focus on practical software delivery and data-oriented work.',
-    tags: ['Healthcare', 'Software Engineering', 'Data'],
-  },
-  {
-    period: 'May 2013 – Jul 2018',
-    role: 'Senior Software Engineer (part-time)',
-    company: 'Ratho BV',
-    desc: 'Part-time side job focused on C/C++ and SQL-heavy engineering, mentoring, and delivery support.',
-    tags: ['C#', 'SQL', 'Mentoring', 'Part-time (5-10%)'],
-  },
-  {
-    period: 'Apr 2013 – Present',
-    role: 'Software en Data Professional (self-employed)',
-    company: 'pieterkuppens.net',
-    desc: 'Independent practice delivering software and data projects across healthcare, finance, and high-tech.',
-    tags: ['Freelance', 'Python', 'C#/.NET', 'C/C++', 'SQL'],
-  },
-  {
-    period: 'Dec 2012 – Apr 2013',
-    role: 'Technical Engineer',
-    company: 'Blueriq',
-    desc: 'Short assignment focusing on frontend-oriented engineering in a professional software environment.',
-    tags: ['Frontend', 'WPF', 'HTML/CSS'],
-  },
-  {
-    period: 'Jul 2012 – Nov 2012',
-    role: 'Technical Engineer',
-    company: 'ABN AMRO Bank',
-    desc: 'Engineering work in a banking environment with focus on secure enterprise delivery.',
-    tags: ['Security', 'Enterprise', 'C#/.NET', 'MSSQL'],
-  },
-  {
-    period: 'Apr 2012 – Jun 2012',
-    role: 'Security Specialist',
-    company: 'ABN AMRO Lease',
-    desc: 'Security-focused work including SMS 2FA and password policy improvements.',
-    tags: ['Security', '2FA', 'Policies'],
-  },
-  {
-    period: 'Apr 2012 – Apr 2013',
-    role: 'Technical Engineer',
-    company: 'Everest BV',
-    desc: 'Technical engineering role across a one-year period (overlapping with short assignments).',
-    tags: ['Engineering', 'Consulting'],
-  },
-  {
-    period: '2011 – 2012',
-    role: 'Software Designer',
-    company: 'Philips Healthcare',
-    desc: 'Contributed to medical software with 3D visualization support for ablation treatment use cases.',
-    tags: ['Healthcare', 'Scientific Software', 'C/C++', 'Visualization'],
-  },
-  {
-    period: '2010',
-    role: 'Software Engineer',
-    company: 'BOSOR',
-    desc: 'Contributed to frontend to planning software',
-    tags: ['Delphi', 'JavaScript'],
-  },
-  {
-    period: '1997 – 2009',
-    role: 'Software Designer',
-    company: 'ASML',
-    desc: 'Long-tenure high-tech engineering on complex software projects in large-scale semiconductor systems.',
-    tags: ['High-Tech', 'C/C++', 'Engineering', 'Long-term'],
-  },
-]
-
-const PREFERENCES = [
-  { label: 'Location', value: 'Netherlands (Den Bosch-Eindhoven), hybrid/remote' },
-  { label: 'Preferred domains', value: 'Healthcare, Finance, High-Tech, Data and AI' },
-  { label: 'Rate range', value: '€100–€140/hour' },
-  { label: 'Contract duration', value: '3–18 months preferred' },
-  { label: 'Min. hours/week', value: '32 hours minimum' },
-  { label: 'Travel', value: 'Max 3-4 hour commute weekly, rest remote' },
-]
-
-const TECH = {
-  'Core Languages': ['Python', 'C#/.NET', 'C/C++', 'SQL', 'JavaScript'],
-  'Data and AI': ['GenAI', 'LLM', 'RAG', 'AI-assisted development', 'Deep Learning', 'NLP Support', 'Transaction Monitoring AI', 'Data Pipelines'],
-  'Cloud and DevOps': ['Azure', 'AWS', 'CI/CD', 'Docker', 'Jira/Confluence/Bitbucket'],
-  'Security and Compliance': ['SMS 2FA', 'Password Policies', 'ISO 13485 Context', 'IEC 62304 Context'],
-  'Databases and Storage': ['MSSQL', 'SQLite', 'MySQL', 'PostgreSQL'],
-}
 
 export default function ProfilePage() {
   return (
@@ -145,7 +25,7 @@ export default function ProfilePage() {
         <div className="container">
           <h2 className="mb-4">Work Preferences</h2>
           <div className={styles.prefGrid}>
-            {PREFERENCES.map(p => (
+            {DISPLAY_PREFERENCES.map(p => (
               <div key={p.label} className={`card ${styles.prefCard}`}>
                 <div className={styles.prefLabel}>{p.label}</div>
                 <div className={styles.prefValue}>{p.value}</div>
@@ -183,7 +63,7 @@ export default function ProfilePage() {
         <div className="container">
           <h2 className="mb-4">Technology Stack</h2>
           <div className={styles.techGrid}>
-            {Object.entries(TECH).map(([cat, items]) => (
+            {Object.entries(TECH_STACK).map(([cat, items]) => (
               <div key={cat} className="card">
                 <h3 className={styles.techCat}>{cat}</h3>
                 <div className={`flex flex-wrap gap-1 mt-2`}>

--- a/src/pages/evaluator/EvaluatorPage.tsx
+++ b/src/pages/evaluator/EvaluatorPage.tsx
@@ -1,58 +1,20 @@
-import { useState, useCallback } from 'react'
-import type { EvaluationResult, OpportunityInput, ProfilePreferences } from '../../domain/evaluator/types'
-import { DEFAULT_PREFERENCES } from '../../domain/evaluator/defaultPreferences'
-import { CRITERIA } from '../../domain/evaluator/criteria'
-import { evaluateOpportunity } from '../../domain/evaluator/scoring'
-import { loadFromStorage, saveToStorage } from '../../infrastructure/storage'
 import EvaluatorForm from './EvaluatorForm'
 import EvaluatorResults from './EvaluatorResults'
 import PreferencesPanel from './PreferencesPanel'
+import { useEvaluatorSession } from './useEvaluatorSession'
 import styles from './EvaluatorPage.module.css'
 
-const PREFS_KEY = 'evaluator_preferences'
-const INPUT_KEY = 'evaluator_last_input'
-
-const DEFAULT_INPUT: OpportunityInput = {
-  title: '',
-  domain: '',
-  hoursPerWeek: 40,
-  hourlyRate: 110,
-  commuteMinutes: 30,
-  hybridDaysOnsite: 2,
-  durationMonths: 6,
-  technologies: [],
-  notes: '',
-}
-
-type Tab = 'evaluate' | 'preferences'
-
 export default function EvaluatorPage() {
-  const [activeTab, setActiveTab] = useState<Tab>('evaluate')
-  const [prefs, setPrefs] = useState<ProfilePreferences>(() =>
-    loadFromStorage(PREFS_KEY, DEFAULT_PREFERENCES)
-  )
-  const [input, setInput] = useState<OpportunityInput>(() =>
-    loadFromStorage(INPUT_KEY, DEFAULT_INPUT)
-  )
-  const [result, setResult] = useState<EvaluationResult | null>(null)
-
-  const handleEvaluate = useCallback((opportunityInput: OpportunityInput) => {
-    saveToStorage(INPUT_KEY, opportunityInput)
-    setInput(opportunityInput)
-    const evaluation = evaluateOpportunity(opportunityInput, prefs, CRITERIA)
-    setResult(evaluation)
-  }, [prefs])
-
-  const handlePrefsChange = useCallback((newPrefs: ProfilePreferences) => {
-    saveToStorage(PREFS_KEY, newPrefs)
-    setPrefs(newPrefs)
-    setResult(null)
-  }, [])
-
-  const handleReset = useCallback(() => {
-    setInput(DEFAULT_INPUT)
-    setResult(null)
-  }, [])
+  const {
+    activeTab,
+    setActiveTab,
+    prefs,
+    input,
+    result,
+    handleEvaluate,
+    handlePrefsChange,
+    handleReset,
+  } = useEvaluatorSession()
 
   return (
     <>

--- a/src/pages/evaluator/EvaluatorResults.tsx
+++ b/src/pages/evaluator/EvaluatorResults.tsx
@@ -1,15 +1,9 @@
-import type { EvaluationResult, ScoreLevel } from '../../domain/evaluator/types'
+import type { EvaluationResult } from '../../domain/evaluator/types'
+import { getRawScoreColor, LEVEL_PRESENTATION } from '../../domain/evaluator/scoreBands'
 import styles from './EvaluatorResults.module.css'
 
 interface Props {
   result: EvaluationResult
-}
-
-const LEVEL_CONFIG: Record<ScoreLevel, { label: string; color: string; bg: string }> = {
-  excellent: { label: 'Excellent fit', color: '#16a34a', bg: '#f0fdf4' },
-  good: { label: 'Good fit', color: '#2563eb', bg: '#eff6ff' },
-  fair: { label: 'Fair fit', color: '#d97706', bg: '#fffbeb' },
-  poor: { label: 'Poor fit', color: '#dc2626', bg: '#fef2f2' },
 }
 
 function ScoreBar({ score, color }: { score: number; color: string }) {
@@ -17,10 +11,10 @@ function ScoreBar({ score, color }: { score: number; color: string }) {
     <div className={styles.scoreBarTrack}>
       <div
         className={styles.scoreBarFill}
-        style={{ width: `${score}%`, background: color }}
+        style={{ width: `${Math.max(0, Math.min(100, score))}%`, background: color }}
         role="progressbar"
         aria-valuenow={score}
-        aria-valuemin={0}
+        aria-valuemin={-100}
         aria-valuemax={100}
       />
     </div>
@@ -28,7 +22,7 @@ function ScoreBar({ score, color }: { score: number; color: string }) {
 }
 
 export default function EvaluatorResults({ result }: Props) {
-  const cfg = LEVEL_CONFIG[result.level]
+  const cfg = LEVEL_PRESENTATION[result.level]
 
   return (
     <div className={styles.results} aria-label="Evaluation results">
@@ -51,10 +45,7 @@ export default function EvaluatorResults({ result }: Props) {
               <span className={styles.criterionLabel}>{cs.label}</span>
               <span className={styles.criterionScore}>{cs.rawScore}%</span>
             </div>
-            <ScoreBar
-              score={cs.rawScore}
-              color={cs.rawScore >= 80 ? '#16a34a' : cs.rawScore >= 60 ? '#2563eb' : cs.rawScore >= 40 ? '#d97706' : '#dc2626'}
-            />
+            <ScoreBar score={cs.rawScore} color={getRawScoreColor(cs.rawScore)} />
             <div className={styles.criterionMeta}>
               Weight: {cs.weight} · Contribution: {cs.weightedScore.toFixed(1)} pts
             </div>

--- a/src/pages/evaluator/useEvaluatorSession.ts
+++ b/src/pages/evaluator/useEvaluatorSession.ts
@@ -1,0 +1,48 @@
+import { useState, useCallback } from 'react'
+import type { EvaluationResult, OpportunityInput, ProfilePreferences } from '../../domain/evaluator/types'
+import {
+  createDefaultOpportunityInput,
+  loadEvaluatorInput,
+  loadEvaluatorPreferences,
+  persistEvaluatorInput,
+  persistEvaluatorPreferences,
+  runEvaluation,
+} from '../../domain/evaluator/evaluatorSession'
+
+export type EvaluatorTab = 'evaluate' | 'preferences'
+
+export function useEvaluatorSession() {
+  const [prefs, setPrefs] = useState<ProfilePreferences>(loadEvaluatorPreferences)
+  const [input, setInput] = useState<OpportunityInput>(() => loadEvaluatorInput())
+  const [result, setResult] = useState<EvaluationResult | null>(null)
+  const [activeTab, setActiveTab] = useState<EvaluatorTab>('evaluate')
+
+  const handleEvaluate = useCallback((opportunityInput: OpportunityInput) => {
+    persistEvaluatorInput(opportunityInput)
+    setInput(opportunityInput)
+    setResult(runEvaluation(opportunityInput, prefs))
+  }, [prefs])
+
+  const handlePrefsChange = useCallback((newPrefs: ProfilePreferences) => {
+    persistEvaluatorPreferences(newPrefs)
+    setPrefs(newPrefs)
+    setResult(null)
+  }, [])
+
+  const handleReset = useCallback(() => {
+    const defaults = createDefaultOpportunityInput(prefs)
+    setInput(defaults)
+    setResult(null)
+  }, [prefs])
+
+  return {
+    activeTab,
+    setActiveTab,
+    prefs,
+    input,
+    result,
+    handleEvaluate,
+    handlePrefsChange,
+    handleReset,
+  }
+}


### PR DESCRIPTION
## Summary
- Unifies Profile content (CV, display preferences, evaluator defaults) in `src/domain/profile/`
- Extracts evaluator session orchestration, shared score bands, and unified theme/storage keys
- Adds weighted commute scoring (`commuteScore.ts`) with sqrt(onsite-day) penalty; long commutes on full onsite score below zero
- Adds unit tests and updates ADRs, arc42, and `CONTEXT.md`

## Test plan
- [x] `npm test` (102 tests)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] Manual smoke: Opportunity Evaluator form submit and preferences tab
- [ ] Verify Profile page rate range matches evaluator defaults (€100–€140)
