### PR TITLE
chore: v0.9.0 prep — health retry, audit fix

### DIFF
--- a/.github/workflows/site-health.yml
+++ b/.github/workflows/site-health.yml
@@ -1,5 +1,7 @@
 # Live Playwright checks against https://pkuppens.github.io/
 # Post-deploy runs use workflow_run so we do not race Pages propagation (see #44).
+# Post-deploy health uses incremental retry (scripts/run-site-health-with-retry.sh).
+# On final failure, GitHub sends workflow-failure emails to watchers (repo notification settings).
 name: Site health (GitHub Pages)
 
 on:
@@ -22,7 +24,7 @@ concurrency:
 jobs:
   healthcheck:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 75
     if: |
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -51,9 +53,10 @@ jobs:
       - name: Install Playwright (Chromium)
         run: npx playwright install --with-deps chromium
 
-      - name: Short wait for CDN (after deploy only)
+      - name: Run live site healthcheck (post-deploy retry)
         if: github.event_name == 'workflow_run'
-        run: sleep 45
+        run: bash scripts/run-site-health-with-retry.sh
 
       - name: Run live site healthcheck
+        if: github.event_name != 'workflow_run'
         run: npm run test:site-health

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,6 +30,9 @@ All `localStorage` access uses the `pkuppens_` prefix via `src/infrastructure/st
 **Visitor preference overrides**
 Visitors may edit scoring preferences in the UI; those overrides are stored per browser. The versioned **Profile** in the repo remains the default when storage is empty. See ADR 003.
 
+**Post-deploy verification**
+Automated check that the live GitHub Pages site matches expectations after a deploy. May retry with backoff when the CDN has not caught up yet.
+
 ## Out of scope (parked)
 
 **LinkedIn experience mirror**

--- a/docs/arc42/architecture.md
+++ b/docs/arc42/architecture.md
@@ -70,7 +70,7 @@ src/
 ### Testing Strategy
 - Unit tests: criteria, scoring, profile consistency, evaluator session, storage (Vitest)
 - Component tests: React Testing Library
-- E2E tests: Playwright site-health smoke (`e2e/site-health.spec.ts`)
+- E2E tests: Playwright site-health smoke (`e2e/site-health.spec.ts`); post-deploy runs retry with incremental backoff (`scripts/run-site-health-with-retry.sh`)
 
 ### State Management
 - Local component state (useState) for UI

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pkuppens-github-io",
-  "version": "0.1.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pkuppens-github-io",
-      "version": "0.1.0",
+      "version": "0.9.0",
       "dependencies": {
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
@@ -1844,9 +1844,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pkuppens-github-io",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -13,6 +13,7 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:site-health": "playwright test e2e/site-health.spec.ts",
+    "test:site-health:retry": "bash scripts/run-site-health-with-retry.sh",
     "linkedin:validate": "node scripts/linkedin/validate.mjs",
     "linkedin:export:json": "node scripts/linkedin/export-json.mjs",
     "linkedin:export:csv": "node scripts/linkedin/export-csv.mjs",

--- a/scripts/run-site-health-with-retry.sh
+++ b/scripts/run-site-health-with-retry.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Post-deploy live site health: retry Playwright with incremental backoff.
+# Env: SITE_HEALTH_MAX_ATTEMPTS (default 5), SITE_HEALTH_DELAYS_SEC (default 0,120,300,600,900)
+
+set -euo pipefail
+
+MAX_ATTEMPTS="${SITE_HEALTH_MAX_ATTEMPTS:-5}"
+DELAYS_CSV="${SITE_HEALTH_DELAYS_SEC:-0,120,300,600,900}"
+
+IFS=',' read -r -a DELAYS <<< "$DELAYS_CSV"
+
+if ((${#DELAYS[@]} < MAX_ATTEMPTS)); then
+  echo "SITE_HEALTH_DELAYS_SEC must have at least $MAX_ATTEMPTS values (got ${#DELAYS[@]})" >&2
+  exit 1
+fi
+
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+  echo "Site health attempt $attempt/$MAX_ATTEMPTS"
+  if npm run test:site-health; then
+    echo "Site health passed on attempt $attempt"
+    exit 0
+  fi
+
+  if ((attempt == MAX_ATTEMPTS)); then
+    echo "Site health failed after $MAX_ATTEMPTS attempts" >&2
+    exit 1
+  fi
+
+  wait_sec="${DELAYS[$attempt]}"
+  echo "Attempt $attempt/$MAX_ATTEMPTS failed; waiting ${wait_sec}s before retry"
+  sleep "$wait_sec"
+done
+
+exit 1

--- a/src/domain/evaluator/criteria.ts
+++ b/src/domain/evaluator/criteria.ts
@@ -54,7 +54,8 @@ export const CRITERIA: CriterionConfig[] = [
     id: 'commute',
     label: 'Commute',
     weight: 15,
-    evaluate(input: OpportunityInput, _prefs: ProfilePreferences): number {
+    evaluate(input: OpportunityInput, prefs: ProfilePreferences): number {
+      void prefs
       return Math.round(scoreCommute(input.commuteMinutes, input.hybridDaysOnsite))
     },
   },


### PR DESCRIPTION
## Summary
- Bump `package.json` to **0.9.0**
- Replace post-deploy `sleep 45` with **incremental retry** (5 attempts, 0→2→5→10→15m backoff) via `scripts/run-site-health-with-retry.sh`
- Fix **npm audit** moderate `brace-expansion` finding (`npm audit fix`)
- Document post-deploy verification in `CONTEXT.md` and arc42

Contributes to #25

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (102 tests)
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [ ] After merge: Site health workflow on `workflow_run` (expect pass on attempt 1 or visible retries in log)
