### PR TITLE
[Portfolio] Quality gates: add lint to CI, create PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- Brief description of what this PR does and why. -->
+
+## Pre-merge manual smoke test
+
+- [ ] Home: first screen — role, how to contact, one proof path (Projects/link) in ~10s.
+- [ ] Projects: open at least one external case study link.
+- [ ] Profile: no placeholder employers for periods covered on LinkedIn.
+- [ ] Evaluator: one evaluation completes.
+
+## CI validation
+
+- [ ] `npm run lint` — passes with 0 warnings
+- [ ] `npm run typecheck` — passes
+- [ ] `npm test` — all tests pass
+- [ ] `npm run build` — production build succeeds
+
+## Post-merge / deploy
+
+- [ ] After merge to `main`, confirm [GitHub Actions deploy](https://github.com/pkuppens/pkuppens.github.io/actions) completes
+- [ ] [https://pkuppens.github.io](https://pkuppens.github.io) loads and routes work on refresh (no 404 for SPA paths)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Type check
         run: npm run typecheck
 


### PR DESCRIPTION
## Summary

Adds \
pm run lint\ to the CI pipeline (was a gap — script existed but never ran in CI) and creates a PR template with the pre-merge/post-deploy verification checklist.

## Changes

| File | Change |
|------|--------|
| \.github/workflows/deploy.yml\ | Add \
pm run lint\ step before typecheck in \uild-and-test\ job |
| \.github/PULL_REQUEST_TEMPLATE.md\ | New file: pre-merge smoke checklist (Home, Projects, Profile, Evaluator), CI validation (lint, typecheck, test, build), and post-deploy verification |

## Verification

- [ ] \
pm run lint\ — passes with 0 warnings
- [ ] \
pm run typecheck\ — passes
- [ ] \
pm test\ — 102/102 tests pass
- [ ] \
pm run build\ — production build succeeds
- [ ] CI triggers on PR to \main\ (deploy.yml has \pull_request: branches: [main]\)
- [ ] PR template renders when creating a new PR

Closes #24