### PR TITLE
fix: commute calculator follow-ups (home address, scoring, validation)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# HERE API Key for Commute Calculator
+# ====================================
+# Get a free API key at https://platform.here.com/
+# 1. Sign up / log in at platform.here.com
+# 2. Click the grid icon (launcher) top-right → Access Manager → Apps tab
+# 3. Register a new app, then on Credentials tab click "Create API Key"
+# 4. Subscribe to "Geocoding & Search API v7" + "Routing API v8" on the APIs tab
+# 5. Under "Trusted domains", add: localhost, pkuppens.github.io → toggle ON
+# 6. Copy the key and set it below.
+#
+# SAFETY NOTES:
+# - .env is in .gitignore — safe from git exposure
+# - BUT the key IS compiled into the JS bundle (visible in browser DevTools)
+# - Mitigate via HERE portal's trusted domains + rate limits
+# - For maximum safety, skip this file and enter the key in the Preferences
+#   panel in-browser instead (stored in localStorage, not in the bundle).
+#   The Preferences panel key takes precedence over this env var.
+VITE_HERE_API_KEY=

--- a/.github/workflows/cleanup-obsolete-actions-runs.yml
+++ b/.github/workflows/cleanup-obsolete-actions-runs.yml
@@ -3,6 +3,8 @@ name: Cleanup obsolete Actions runs
 on:
   push:
     branches: [main]
+  schedule:
+    - cron: "0 6 * * 0"  # weekly on Sunday 06:00 UTC
   workflow_dispatch:
     inputs:
       min_age_days:
@@ -40,7 +42,7 @@ jobs:
       # Defaults for push-to-main runs (real deletion).
       MIN_AGE_DAYS: 0
       MAX_DELETIONS: 200
-      DRY_RUN: "true"
+      DRY_RUN: "false"
 
     steps:
       - name: Cleanup obsolete runs (push)

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ test-results
 
 # Local scratch (LinkedIn scrape output, persistent browser profile)
 tmp/
+
+# Environment variables (API keys, local overrides)
+.env

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,13 +25,27 @@ A labelled range for a 0–100 score (excellent / good / fair / poor) with share
 ## Persistence
 
 **Storage keys**
-All `localStorage` access uses the `pkuppens_` prefix via `src/infrastructure/storage.ts`. Keys are listed in `storageKeys.ts` (evaluator input, evaluator preferences, theme).
+All `localStorage` access uses the `pkuppens_` prefix via `src/infrastructure/storage.ts`. Keys are listed in `storageKeys.ts` (evaluator input, evaluator preferences, theme, home address, HERE API key).
 
 **Visitor preference overrides**
 Visitors may edit scoring preferences in the UI; those overrides are stored per browser. The versioned **Profile** in the repo remains the default when storage is empty. See ADR 003.
 
 **Post-deploy verification**
 Automated check that the live GitHub Pages site matches expectations after a deploy. May retry with backoff when the CDN has not caught up yet.
+
+## Commute calculator
+
+**HERE API client**
+`src/infrastructure/hereApi.ts` provides `geocodeAddress`, `fetchRoute`, and `fetchCommute` functions that call HERE Geocoding & Search API v7 and Routing API v8. The API key is resolved from localStorage (user-provided) or `VITE_HERE_API_KEY` (build-time fallback).
+
+**CommuteCalculator component**
+`src/pages/evaluator/CommuteCalculator.tsx` renders address inputs, a Calculate button, and result cards for car and public transport. It lives inline in `EvaluatorForm` below the commute minutes field. An "Apply" button fills `commuteMinutes` from the calculated car duration.
+
+**API Key**
+Users enter their key in the Preferences panel; it is stored in localStorage via `homeAddressStorage.ts` / `storageKeys.ts`. When no key is present the calculator shows a message prompting configuration rather than crashing. See ADR 004.
+
+**Origin persistence**
+The "Remember origin" checkbox allows optional localStorage persistence of the origin address.
 
 ## Out of scope (parked)
 

--- a/docs/adr/004-here-api-integration.md
+++ b/docs/adr/004-here-api-integration.md
@@ -1,0 +1,72 @@
+# ADR 004: HERE Routing API Integration for Commute Calculator
+
+## Status
+
+Accepted
+
+## Context
+
+The Opportunity Evaluator needs a commute distance/time calculator so users can enter Dutch addresses and get commute times for car and public transport without guessing commute minutes.
+
+The site is statically hosted on GitHub Pages with no backend. The HERE Routing API v8 and Geocoding & Search API v7 provide these capabilities via REST endpoints with CORS support, making them usable from a client-side-only deployment.
+
+Existing commute scoring logic (`commuteScore.ts`) uses a single `commuteMinutes` field on `OpportunityInput`. The HERE integration must populate this field.
+
+## Decision
+
+We will integrate HERE APIs as a client-side integration:
+
+- **Geocoding:** `geocode.search.hereapi.com/v1/geocode` — resolve Dutch addresses to coordinates
+- **Routing:** `router.hereapi.com/v8/routes` — calculate routes for car and public transport
+- **Transport:** native `fetch`, no additional SDK or dependency
+
+### API Key Strategy
+
+Two-tier resolution:
+
+1. **User-provided key (preferred):** Entered in the Preferences panel, stored in `localStorage` under `pkuppens_here_api_key`
+2. **Build-time key (fallback):** `VITE_HERE_API_KEY` environment variable compiled into the bundle
+
+Users without a key see a disabled commute calculator with a link to get a free key at `platform.here.com`. This avoids hard-coding secrets that would be visible in the client bundle unless the developer explicitly chooses to embed one.
+
+### API Key Security
+
+- A key stored in `localStorage` is visible only to the user's browser session
+- A VITE-compiled key is visible in the client bundle — mitigate via HERE portal domain restriction + rate limits
+- Never log or display the API key in error messages or diagnostics
+- No addresses are persisted in `localStorage` by default
+
+### Address Persistence
+
+- Addresses are **not** stored in `localStorage` by default
+- Users may opt in to save their origin address via a "Remember origin" checkbox
+- Opt-in persistence uses `pkuppens_home_address` key in `localStorage`
+
+## Consequences
+
+### Positive
+
+- No backend infrastructure needed
+- Fully client-side, deployable on GitHub Pages
+- Users can get commute times without guessing
+- All existing scoring logic unchanged — `commuteMinutes` is the only integration point
+- Graceful degradation: no key = no crash, just disabled UI
+
+### Negative
+
+- Public transport routing may require a specific HERE plan — handled via graceful degradation (shows "not available")
+- No offline capability — HERE API requires internet
+- Two API calls per mode (geocode origin + geocode dest + route calls), which is slower than a batched endpoint
+
+### Risks
+
+- HERE API changes could break the integration (mitigated by using stable v7/v8 endpoints with versioned URLs)
+- Rate limits could impact heavy users (mitigated by user-facing error messages and the `rate_limited` error category)
+- API key abuse is possible on a static site — mitigated by HERE portal referrer restrictions + rate limits
+
+## Alternatives Considered
+
+1. **OpenStreetMap + OSRM** — free but less reliable for Dutch addresses and PT
+2. **Google Maps API** — similar approach but different billing model
+3. **Server-side proxy** — not feasible for GitHub Pages static hosting
+4. **Manual entry only** — existing behavior, but the issue specifically requested automated calculation

--- a/src/domain/evaluator/__tests__/commuteScore.test.ts
+++ b/src/domain/evaluator/__tests__/commuteScore.test.ts
@@ -2,45 +2,54 @@ import { describe, it, expect } from 'vitest'
 import { commuteDegradation, scoreCommute } from '../commuteScore'
 
 describe('commuteDegradation', () => {
-  it('returns 0 up to 10 minutes per day', () => {
+  it('returns 0 up to 15 minutes one-way (30 min round trip free)', () => {
     expect(commuteDegradation(0)).toBe(0)
     expect(commuteDegradation(10)).toBe(0)
+    expect(commuteDegradation(15)).toBe(0)
   })
 
-  it('degrades linearly from 10 to 60 minutes', () => {
-    expect(commuteDegradation(35)).toBe(50)
-    expect(commuteDegradation(60)).toBe(100)
+  it('degrades linearly based on round-trip excess beyond 30 min', () => {
+    // 35 min one-way = 70 min round trip = 40 min excess
+    // 40/120 * 100 = 33.33...
+    expect(commuteDegradation(35)).toBeCloseTo(33.33, 0)
+    // 60 min one-way = 120 min round trip = 90 min excess
+    // 90/120 * 100 = 75
+    expect(commuteDegradation(60)).toBe(75)
   })
 
-  it('adds up to 60 penalty points from 60 to 90 minutes', () => {
-    expect(commuteDegradation(75)).toBe(130)
-    expect(commuteDegradation(90)).toBe(160)
+  it('reaches 100 degradation at 75 min one-way (150 min round trip = 120 excess)', () => {
+    expect(commuteDegradation(75)).toBe(100)
+  })
+
+  it('extends degradation beyond 100 up to 200 for extreme commutes', () => {
+    // 90 min one-way = 180 min round trip = 150 min excess
+    // 100 + (150-120)/120*100 = 100 + 25 = 125
+    expect(commuteDegradation(90)).toBe(125)
+    // 135 min one-way = 270 min round trip = 240 min excess → cap at 200
+    expect(commuteDegradation(135)).toBe(200)
   })
 })
 
 describe('scoreCommute', () => {
-  it('returns 100 for fully remote (0 onsite days)', () => {
+  it('returns 100 for fully remote (0 onsite days) regardless of commute', () => {
     expect(scoreCommute(120, 0)).toBe(100)
+  })
+
+  it('returns 100 for any commute under 15 min one-way regardless of days', () => {
+    expect(scoreCommute(11, 2)).toBe(100)
+    expect(scoreCommute(15, 5)).toBe(100)
   })
 
   it('penalises full onsite with a long commute below zero', () => {
     expect(scoreCommute(90, 5)).toBeLessThan(0)
   })
 
-  it('returns 100 for full onsite when commute is acceptable', () => {
-    expect(scoreCommute(10, 5)).toBe(100)
+  it('scores 25% for 60 min one-way with 1 onsite day', () => {
+    expect(scoreCommute(60, 1)).toBe(25)
   })
 
-  it('returns 100 when commute is within 10 minutes on hybrid days', () => {
-    expect(scoreCommute(10, 2)).toBe(100)
-  })
-
-  it('scores 0% for 60 minutes with 1 onsite day', () => {
-    expect(scoreCommute(60, 1)).toBe(0)
-  })
-
-  it('scores -100% for 60 minutes with 4 onsite days', () => {
-    expect(scoreCommute(60, 4)).toBe(-100)
+  it('scores -50% for 60 min one-way with 4 onsite days', () => {
+    expect(scoreCommute(60, 4)).toBe(-50)
   })
 
   it('scales penalty by sqrt(onsite days)', () => {

--- a/src/domain/evaluator/__tests__/criteria.test.ts
+++ b/src/domain/evaluator/__tests__/criteria.test.ts
@@ -78,16 +78,16 @@ describe('criteria', () => {
       ).toBeLessThan(0)
     })
 
-    it('returns 0 for 60 minutes with 1 onsite day', () => {
+    it('scores 25 for 60 minutes with 1 onsite day', () => {
       expect(
         scoreCriterion('commute', { ...baseInput, commuteMinutes: 60, hybridDaysOnsite: 1 }),
-      ).toBe(0)
+      ).toBe(25)
     })
 
-    it('returns -100 for 60 minutes with 4 onsite days', () => {
+    it('scores -50 for 60 minutes with 4 onsite days', () => {
       expect(
         scoreCriterion('commute', { ...baseInput, commuteMinutes: 60, hybridDaysOnsite: 4 }),
-      ).toBe(-100)
+      ).toBe(-50)
     })
   })
 

--- a/src/domain/evaluator/commuteScore.ts
+++ b/src/domain/evaluator/commuteScore.ts
@@ -1,39 +1,42 @@
 /**
  * Commute criterion scoring (0–100 raw score; may go negative before weighting).
  *
- * One-way `commuteMinutes` is compared to per-day thresholds. Degradation is
- * multiplied by sqrt(onsite days per week) so more office days amplify the penalty.
+ * The first 30 minutes of round-trip commute per day are free (15 min one-way).
+ * Degradation is based on round-trip excess beyond 30 min/day:
+ *   - 0 min excess → 0 degradation (100% score)
+ *   - 120 min excess → 100 degradation (0% score)
+ *   - 240 min excess → 200 degradation (-100% score)
+ * Degradation is amplified by sqrt(onsite days per week).
  */
 
-const ACCEPTABLE_MINUTES = 10
-const LINEAR_MAX_MINUTES = 60
-const PENALTY_MAX_MINUTES = 90
-const MAX_EXTRA_PENALTY = 60
+const FREE_ROUND_TRIP_MINUTES = 30
+const EXCESS_TO_ZERO_SCORE = 120
+const MAX_EXCESS = 240
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
 }
 
 /**
- * Degradation points subtracted from 100 before onsite-day weighting.
- * Up to 10 min/day: 0. Linear 10→60: 0→100. Extra 60→90: up to +60 penalty.
+ * Degradation points (0–200) based on round-trip commute excess.
  */
 export function commuteDegradation(commuteMinutes: number): number {
-  if (commuteMinutes <= ACCEPTABLE_MINUTES) return 0
+  const roundTrip = 2 * commuteMinutes
+  const excess = Math.max(0, roundTrip - FREE_ROUND_TRIP_MINUTES)
 
-  if (commuteMinutes <= LINEAR_MAX_MINUTES) {
-    return ((commuteMinutes - ACCEPTABLE_MINUTES) / (LINEAR_MAX_MINUTES - ACCEPTABLE_MINUTES)) * 100
+  if (excess <= 0) return 0
+
+  if (excess <= EXCESS_TO_ZERO_SCORE) {
+    return (excess / EXCESS_TO_ZERO_SCORE) * 100
   }
 
-  const linearDegradation = 100
-  if (commuteMinutes <= PENALTY_MAX_MINUTES) {
-    const extra =
-      ((commuteMinutes - LINEAR_MAX_MINUTES) / (PENALTY_MAX_MINUTES - LINEAR_MAX_MINUTES)) *
-      MAX_EXTRA_PENALTY
-    return linearDegradation + extra
+  if (excess <= MAX_EXCESS) {
+    const extraExcess = excess - EXCESS_TO_ZERO_SCORE
+    const extraDegradation = (extraExcess / (MAX_EXCESS - EXCESS_TO_ZERO_SCORE)) * 100
+    return 100 + extraDegradation
   }
 
-  return linearDegradation + MAX_EXTRA_PENALTY
+  return 200
 }
 
 /**

--- a/src/domain/evaluator/types.ts
+++ b/src/domain/evaluator/types.ts
@@ -25,6 +25,8 @@ export interface OpportunityInput {
   durationMonths: number
   technologies: string[]
   notes: string
+  commuteOrigin?: string        // home address for commute calculation
+  commuteDestination?: string   // office address for commute calculation
 }
 
 export interface CriterionConfig {

--- a/src/infrastructure/__tests__/hereApi.test.ts
+++ b/src/infrastructure/__tests__/hereApi.test.ts
@@ -1,6 +1,6 @@
 import { it, expect, vi, beforeEach } from "vitest"
 import { geocodeAddress, fetchRoute, fetchCommute } from "../hereApi"
-import type { LatLng, RouteResult } from "../hereApi"
+import type { LatLng, RouteResult, HereApiError } from "../hereApi"
 
 const mockFetch = vi.fn()
 globalThis.fetch = mockFetch
@@ -52,8 +52,8 @@ it("returns rate_limited on HTTP 429", async () => {
 
   const result = await geocodeAddress("Something")
   expect(result).toHaveProperty("category", "rate_limited")
-  expect((result as any).correlationId).toBe("abc-123")
-  expect((result as any).httpStatus).toBe(429)
+  expect((result as HereApiError).correlationId).toBe("abc-123")
+  expect((result as HereApiError).httpStatus).toBe(429)
 })
 
 it("returns network_error on fetch rejection", async () => {
@@ -75,8 +75,8 @@ it("returns api_error on HTTP 403", async () => {
 
   const result = await geocodeAddress("Something")
   expect(result).toHaveProperty("category", "api_error")
-  expect((result as any).httpStatus).toBe(403)
-  expect((result as any).correlationId).toBe("req-403")
+  expect((result as HereApiError).httpStatus).toBe(403)
+  expect((result as HereApiError).correlationId).toBe("req-403")
 })
 
 // ---- fetchRoute ----

--- a/src/infrastructure/__tests__/hereApi.test.ts
+++ b/src/infrastructure/__tests__/hereApi.test.ts
@@ -148,27 +148,25 @@ it("returns api_error for car on HTTP 500", async () => {
 // ---- fetchCommute ----
 
 it("returns results for both modes when all requests succeed", async () => {
-  const geocodeResponse = () =>
-    Promise.resolve({
-      ok: true,
-      status: 200,
-      headers: new Map(),
-      json: async () => ({
-        items: [{ position: { lat: 51.69, lng: 5.3 } }],
-      }),
-    })
+  const geocodeResponse = () => ({
+    ok: true,
+    status: 200,
+    headers: new Map(),
+    json: async () => ({
+      items: [{ position: { lat: 51.69, lng: 5.3 } }],
+    }),
+  })
 
-  const routeResponse = () =>
-    Promise.resolve({
-      ok: true,
-      status: 200,
-      headers: new Map(),
-      json: async () => ({
-        routes: [
-          { sections: [{ summary: { duration: 2700, length: 85000 } }] },
-        ],
-      }),
-    })
+  const routeResponse = () => ({
+    ok: true,
+    status: 200,
+    headers: new Map(),
+    json: async () => ({
+      routes: [
+        { sections: [{ summary: { duration: 2700, length: 85000 } }] },
+      ],
+    }),
+  })
 
   mockFetch
     .mockResolvedValueOnce(geocodeResponse())

--- a/src/infrastructure/__tests__/hereApi.test.ts
+++ b/src/infrastructure/__tests__/hereApi.test.ts
@@ -1,0 +1,236 @@
+import { it, expect, vi, beforeEach } from "vitest"
+import { geocodeAddress, fetchRoute, fetchCommute } from "../hereApi"
+import type { LatLng, RouteResult } from "../hereApi"
+
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.setItem("pkuppens_here_api_key", JSON.stringify("test-key-123"))
+})
+
+// ---- geocodeAddress ----
+
+it("returns LatLng for a valid address", async () => {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Map(),
+    json: async () => ({
+      items: [{ position: { lat: 51.69, lng: 5.3 } }],
+    }),
+  })
+
+  const result = await geocodeAddress("Stationsplein 1, 5211AP, Den Bosch")
+  expect(result).not.toHaveProperty("category")
+  expect((result as LatLng).lat).toBeCloseTo(51.69, 1)
+  expect((result as LatLng).lng).toBeCloseTo(5.3, 1)
+})
+
+it("returns invalid_address when geocoding finds no items", async () => {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Map(),
+    json: async () => ({ items: [] }),
+  })
+
+  const result = await geocodeAddress("Invalid")
+  expect(result).toHaveProperty("category", "invalid_address")
+})
+
+it("returns rate_limited on HTTP 429", async () => {
+  const headers = new Map()
+  headers.set("X-Request-Id", "abc-123")
+  mockFetch.mockResolvedValue({
+    ok: false,
+    status: 429,
+    headers,
+    json: async () => ({}),
+  })
+
+  const result = await geocodeAddress("Something")
+  expect(result).toHaveProperty("category", "rate_limited")
+  expect((result as any).correlationId).toBe("abc-123")
+  expect((result as any).httpStatus).toBe(429)
+})
+
+it("returns network_error on fetch rejection", async () => {
+  mockFetch.mockRejectedValue(new Error("Network failure"))
+
+  const result = await geocodeAddress("Something")
+  expect(result).toHaveProperty("category", "network_error")
+})
+
+it("returns api_error on HTTP 403", async () => {
+  const headers = new Map()
+  headers.set("X-Request-Id", "req-403")
+  mockFetch.mockResolvedValue({
+    ok: false,
+    status: 403,
+    headers,
+    json: async () => ({}),
+  })
+
+  const result = await geocodeAddress("Something")
+  expect(result).toHaveProperty("category", "api_error")
+  expect((result as any).httpStatus).toBe(403)
+  expect((result as any).correlationId).toBe("req-403")
+})
+
+// ---- fetchRoute ----
+
+it("returns RouteResult for a valid car route", async () => {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Map(),
+    json: async () => ({
+      routes: [
+        {
+          sections: [{ summary: { duration: 2700, length: 85000 } }],
+        },
+      ],
+    }),
+  })
+
+  const result = await fetchRoute(
+    { lat: 51.69, lng: 5.3 },
+    { lat: 52.08, lng: 4.31 },
+    "car",
+  )
+  expect(result).not.toHaveProperty("category")
+  expect((result as RouteResult).durationMinutes).toBe(45)
+  expect((result as RouteResult).distanceKm).toBe(85)
+})
+
+it("returns no_route when routes array is empty", async () => {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Map(),
+    json: async () => ({ routes: [] }),
+  })
+
+  const result = await fetchRoute({ lat: 0, lng: 0 }, { lat: 1, lng: 1 }, "car")
+  expect(result).toHaveProperty("category", "no_route")
+})
+
+it("returns no_route for public transport on HTTP 400", async () => {
+  mockFetch.mockResolvedValue({
+    ok: false,
+    status: 400,
+    headers: new Map(),
+    json: async () => ({}),
+  })
+
+  const result = await fetchRoute(
+    { lat: 51.69, lng: 5.3 },
+    { lat: 52.08, lng: 4.31 },
+    "publicTransport",
+  )
+  expect(result).toHaveProperty("category", "no_route")
+})
+
+it("returns api_error for car on HTTP 500", async () => {
+  mockFetch.mockResolvedValue({
+    ok: false,
+    status: 500,
+    headers: new Map(),
+    json: async () => ({}),
+  })
+
+  const result = await fetchRoute({ lat: 0, lng: 0 }, { lat: 1, lng: 1 }, "car")
+  expect(result).toHaveProperty("category", "api_error")
+})
+
+// ---- fetchCommute ----
+
+it("returns results for both modes when all requests succeed", async () => {
+  const geocodeResponse = () =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      headers: new Map(),
+      json: async () => ({
+        items: [{ position: { lat: 51.69, lng: 5.3 } }],
+      }),
+    })
+
+  const routeResponse = () =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      headers: new Map(),
+      json: async () => ({
+        routes: [
+          { sections: [{ summary: { duration: 2700, length: 85000 } }] },
+        ],
+      }),
+    })
+
+  mockFetch
+    .mockResolvedValueOnce(geocodeResponse())
+    .mockResolvedValueOnce(geocodeResponse())
+    .mockResolvedValueOnce(routeResponse())
+    .mockResolvedValueOnce(routeResponse())
+
+  const result = await fetchCommute("Origin", "Destination")
+  expect(result.car).not.toHaveProperty("category")
+  expect(result.publicTransport).not.toHaveProperty("category")
+  expect((result.car as RouteResult).durationMinutes).toBe(45)
+  expect((result.publicTransport as RouteResult).distanceKm).toBe(85)
+})
+
+it("returns null for PT when it fails, car still succeeds", async () => {
+  const geocodeOk = {
+    ok: true,
+    status: 200,
+    headers: new Map(),
+    json: async () => ({
+      items: [{ position: { lat: 51.69, lng: 5.3 } }],
+    }),
+  }
+
+  const routeOk = {
+    ok: true,
+    status: 200,
+    headers: new Map(),
+    json: async () => ({
+      routes: [
+        { sections: [{ summary: { duration: 1800, length: 50000 } }] },
+      ],
+    }),
+  }
+
+  const routeFail = {
+    ok: false,
+    status: 400,
+    headers: new Map(),
+    json: async () => ({}),
+  }
+
+  mockFetch
+    .mockResolvedValueOnce(geocodeOk)
+    .mockResolvedValueOnce(geocodeOk)
+    .mockResolvedValueOnce(routeOk)
+    .mockResolvedValueOnce(routeFail)
+
+  const result = await fetchCommute("O", "D")
+  expect(result.car).not.toHaveProperty("category")
+  expect(result.publicTransport).toHaveProperty("category", "no_route")
+})
+
+it("returns error for both when geocoding fails", async () => {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Map(),
+    json: async () => ({ items: [] }),
+  })
+
+  const result = await fetchCommute("Invalid", "Nowhere")
+  expect(result.car).toHaveProperty("category", "invalid_address")
+  expect(result.publicTransport).toBeNull()
+})

--- a/src/infrastructure/hereApi.ts
+++ b/src/infrastructure/hereApi.ts
@@ -1,0 +1,198 @@
+import { loadFromStorage } from "./storage"
+import { STORAGE_KEYS } from "./storageKeys"
+
+export type TransportMode = "car" | "publicTransport"
+
+export type ErrorCategory =
+  | "no_route"
+  | "invalid_address"
+  | "rate_limited"
+  | "network_error"
+  | "api_error"
+
+export interface LatLng {
+  lat: number
+  lng: number
+}
+
+export interface RouteResult {
+  durationMinutes: number
+  distanceKm: number
+}
+
+export interface HereApiError {
+  category: ErrorCategory
+  message: string
+  httpStatus?: number
+  correlationId?: string
+}
+
+export interface CommuteResult {
+  car: RouteResult | HereApiError
+  publicTransport: RouteResult | HereApiError | null
+}
+
+const HERE_GEOCODE_BASE = "https://geocode.search.hereapi.com/v1"
+const HERE_ROUTE_BASE = "https://router.hereapi.com/v8"
+
+export function getApiKey(): string {
+  const fromStorage = loadFromStorage<string>(STORAGE_KEYS.hereApiKey, "")
+  if (fromStorage) return fromStorage
+  try {
+    return import.meta.env.VITE_HERE_API_KEY ?? ""
+  } catch {
+    return ""
+  }
+}
+
+async function hereFetch(url: string): Promise<Response | HereApiError> {
+  try {
+    const res = await fetch(url)
+    return res
+  } catch {
+    return {
+      category: "network_error",
+      message: "Network error. Check your connection and try again.",
+    }
+  }
+}
+
+function extractCorrelationId(res: Response): string | undefined {
+  return res.headers.get("X-Request-Id") ?? undefined
+}
+
+export async function geocodeAddress(
+  address: string,
+): Promise<LatLng | HereApiError> {
+  const apiKey = getApiKey()
+  if (!apiKey) {
+    return {
+      category: "api_error",
+      message:
+        "HERE API key is not configured. Enter one in Preferences or set VITE_HERE_API_KEY.",
+    }
+  }
+
+  const url = `${HERE_GEOCODE_BASE}/geocode?q=${encodeURIComponent(address)}&apiKey=${apiKey}&limit=1`
+  const result = await hereFetch(url)
+
+  if ("category" in result) return result
+
+  if (result.status === 429) {
+    return {
+      category: "rate_limited",
+      message: "Too many requests. Please wait and try again.",
+      httpStatus: 429,
+      correlationId: extractCorrelationId(result),
+    }
+  }
+
+  if (!result.ok) {
+    return {
+      category: "api_error",
+      message: `Geocoding failed (${result.status})`,
+      httpStatus: result.status,
+      correlationId: extractCorrelationId(result),
+    }
+  }
+
+  const data = await result.json()
+  if (!data.items || data.items.length === 0) {
+    return {
+      category: "invalid_address",
+      message:
+        "We could not find this address. Please add postal code and house number.",
+    }
+  }
+
+  return {
+    lat: data.items[0].position.lat,
+    lng: data.items[0].position.lng,
+  }
+}
+
+export async function fetchRoute(
+  origin: LatLng,
+  destination: LatLng,
+  mode: TransportMode,
+): Promise<RouteResult | HereApiError> {
+  const apiKey = getApiKey()
+  if (!apiKey) {
+    return {
+      category: "api_error",
+      message: "HERE API key is not configured.",
+    }
+  }
+
+  const url = `${HERE_ROUTE_BASE}/routes?transportMode=${mode}&origin=${origin.lat},${origin.lng}&destination=${destination.lat},${destination.lng}&return=summary&apiKey=${apiKey}`
+  const result = await hereFetch(url)
+
+  if ("category" in result) return result
+
+  if (result.status === 429) {
+    return {
+      category: "rate_limited",
+      message: "Too many requests. Please wait and try again.",
+      httpStatus: 429,
+      correlationId: extractCorrelationId(result),
+    }
+  }
+
+  if (!result.ok) {
+    const corrId = extractCorrelationId(result)
+    if (mode === "publicTransport") {
+      return {
+        category: "no_route",
+        message:
+          "Public transport routing is not available for this route or API plan.",
+        httpStatus: result.status,
+        correlationId: corrId,
+      }
+    }
+    return {
+      category: "api_error",
+      message: `Routing failed (${result.status})`,
+      httpStatus: result.status,
+      correlationId: corrId,
+    }
+  }
+
+  const data = await result.json()
+  if (!data.routes || data.routes.length === 0) {
+    return {
+      category: "no_route",
+      message: "No route found between these addresses.",
+    }
+  }
+
+  const summary = data.routes[0].sections[0].summary
+  return {
+    durationMinutes: Math.round(summary.duration / 60),
+    distanceKm: Math.round((summary.length / 1000) * 10) / 10,
+  }
+}
+
+export async function fetchCommute(
+  originAddr: string,
+  destinationAddr: string,
+): Promise<CommuteResult> {
+  const origin = await geocodeAddress(originAddr)
+  if ("category" in origin) {
+    return { car: origin, publicTransport: null }
+  }
+
+  const destination = await geocodeAddress(destinationAddr)
+  if ("category" in destination) {
+    return { car: destination, publicTransport: null }
+  }
+
+  const [carResult, ptResult] = await Promise.all([
+    fetchRoute(origin, destination, "car"),
+    fetchRoute(origin, destination, "publicTransport"),
+  ])
+
+  return {
+    car: carResult,
+    publicTransport: ptResult,
+  }
+}

--- a/src/infrastructure/hereApi.ts
+++ b/src/infrastructure/hereApi.ts
@@ -165,10 +165,16 @@ export async function fetchRoute(
     }
   }
 
-  const summary = data.routes[0].sections[0].summary
+  const section = data.routes[0].sections?.[0]
+  if (!section) {
+    return {
+      category: "no_route",
+      message: "No route sections found.",
+    }
+  }
   return {
-    durationMinutes: Math.round(summary.duration / 60),
-    distanceKm: Math.round((summary.length / 1000) * 10) / 10,
+    durationMinutes: Math.round(section.summary.duration / 60),
+    distanceKm: Math.round((section.summary.length / 1000) * 10) / 10,
   }
 }
 

--- a/src/infrastructure/homeAddressStorage.ts
+++ b/src/infrastructure/homeAddressStorage.ts
@@ -1,0 +1,14 @@
+import { loadFromStorage, saveToStorage, removeFromStorage } from "./storage"
+import { STORAGE_KEYS } from "./storageKeys"
+
+export function loadHomeAddress(): string | undefined {
+  return loadFromStorage<string | undefined>(STORAGE_KEYS.homeAddress, undefined)
+}
+
+export function saveHomeAddress(address: string): void {
+  saveToStorage(STORAGE_KEYS.homeAddress, address)
+}
+
+export function removeHomeAddress(): void {
+  removeFromStorage(STORAGE_KEYS.homeAddress)
+}

--- a/src/infrastructure/storageKeys.ts
+++ b/src/infrastructure/storageKeys.ts
@@ -3,6 +3,8 @@ export const STORAGE_KEYS = {
   theme: 'theme',
   evaluatorPreferences: 'evaluator_preferences',
   evaluatorLastInput: 'evaluator_last_input',
+  homeAddress: 'home_address',
+  hereApiKey: 'here_api_key',
 } as const
 
 /** Legacy theme key before pkuppens_ prefix migration. */

--- a/src/pages/evaluator/CommuteCalculator.module.css
+++ b/src/pages/evaluator/CommuteCalculator.module.css
@@ -1,0 +1,146 @@
+.calculator {
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  background: var(--color-surface);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius);
+}
+
+.heading {
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+  color: var(--color-text);
+}
+
+.hint {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  margin-bottom: 0.75rem;
+}
+
+.field {
+  margin-bottom: 0.75rem;
+}
+
+.label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.3rem;
+}
+
+.input {
+  width: 100%;
+  padding: 0.5rem 0.7rem;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius);
+  font-size: 0.9rem;
+  font-family: var(--font-sans);
+  background: var(--color-input-bg);
+  color: var(--color-text);
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
+}
+
+.results {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.resultCard {
+  background: var(--color-bg);
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--color-border);
+  font-size: 0.9rem;
+}
+
+.resultCard strong {
+  display: block;
+  margin-bottom: 0.2rem;
+}
+
+.resultCard p {
+  margin: 0;
+}
+
+.labelIcon {
+  vertical-align: middle;
+  margin-right: 0.3rem;
+}
+
+.errorText {
+  color: var(--color-danger);
+  font-size: 0.85rem;
+}
+
+.muted {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.error {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-danger);
+  border-radius: var(--radius);
+}
+
+.diagnostics {
+  margin-top: 0.5rem;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+}
+
+.diagnostics pre {
+  margin-top: 0.3rem;
+  padding: 0.5rem;
+  background: var(--color-surface);
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.checkbox input {
+  accent-color: var(--color-primary);
+}
+
+.layout {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.resultCardLayout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+@media (max-width: 500px) {
+  .resultCardLayout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/pages/evaluator/CommuteCalculator.tsx
+++ b/src/pages/evaluator/CommuteCalculator.tsx
@@ -48,15 +48,20 @@ export default function CommuteCalculator({
     setDiagnostics(null)
     setShowDiag(false)
 
-    const res = await fetchCommute(origin.trim(), destination.trim())
-    setResult(res)
+    try {
+      const res = await fetchCommute(origin.trim(), destination.trim())
+      setResult(res)
 
-    if ("category" in res.car) {
+      if ("category" in res.car) {
+        setStatus("error")
+        setErrorMsg(res.car.message)
+        setDiagnostics(formatDiagnostics(res.car))
+      } else {
+        setStatus("success")
+      }
+    } catch {
       setStatus("error")
-      setErrorMsg(res.car.message)
-      setDiagnostics(formatDiagnostics(res.car))
-    } else {
-      setStatus("success")
+      setErrorMsg("An unexpected error occurred. Please try again.")
     }
   }
 

--- a/src/pages/evaluator/CommuteCalculator.tsx
+++ b/src/pages/evaluator/CommuteCalculator.tsx
@@ -1,0 +1,190 @@
+import { useState } from "react"
+import { fetchCommute } from "../../infrastructure/hereApi"
+import type { CommuteResult, RouteResult, HereApiError } from "../../infrastructure/hereApi"
+import { loadHomeAddress, saveHomeAddress, removeHomeAddress } from "../../infrastructure/homeAddressStorage"
+import styles from "./CommuteCalculator.module.css"
+
+interface Props {
+  commuteOrigin?: string
+  commuteDestination?: string
+  onApply: (minutes: number) => void
+}
+
+type Status = "idle" | "loading" | "success" | "error"
+
+function isRouteResult(r: RouteResult | HereApiError): r is RouteResult {
+  return !("category" in r)
+}
+
+function formatDiagnostics(err: HereApiError): string {
+  const lines: string[] = ["Error category: " + err.category]
+  if (err.httpStatus !== undefined) lines.push("HTTP status: " + err.httpStatus)
+  if (err.correlationId) lines.push("Request ID: " + err.correlationId)
+  lines.push("Timestamp: " + new Date().toISOString())
+  return lines.join("\n")
+}
+
+export default function CommuteCalculator({
+  commuteOrigin = "",
+  commuteDestination = "",
+  onApply,
+}: Props) {
+  const savedOrigin = loadHomeAddress()
+  const [origin, setOrigin] = useState(commuteOrigin || savedOrigin || "")
+  const [destination, setDestination] = useState(commuteDestination || "")
+  const [status, setStatus] = useState<Status>("idle")
+  const [result, setResult] = useState<CommuteResult | null>(null)
+  const [errorMsg, setErrorMsg] = useState("")
+  const [diagnostics, setDiagnostics] = useState<string | null>(null)
+  const [showDiag, setShowDiag] = useState(false)
+  const [rememberOrigin, setRememberOrigin] = useState(!!savedOrigin)
+
+  async function handleCalculate() {
+    if (!origin.trim() || !destination.trim()) return
+
+    setStatus("loading")
+    setResult(null)
+    setErrorMsg("")
+    setDiagnostics(null)
+    setShowDiag(false)
+
+    const res = await fetchCommute(origin.trim(), destination.trim())
+    setResult(res)
+
+    if ("category" in res.car) {
+      setStatus("error")
+      setErrorMsg(res.car.message)
+      setDiagnostics(formatDiagnostics(res.car))
+    } else {
+      setStatus("success")
+    }
+  }
+
+  function handleApply() {
+    if (!result || "category" in result.car) return
+    onApply(result.car.durationMinutes)
+    if (rememberOrigin) {
+      saveHomeAddress(origin)
+    } else {
+      removeHomeAddress()
+    }
+  }
+
+  const canCalculate = status !== "loading" && origin.trim() && destination.trim()
+
+  return (
+    <div className={styles.calculator}>
+      <h3 className={styles.heading}>Commute Calculator</h3>
+      <p className={styles.hint}>
+        Enter Dutch addresses: <em>Street + house number, postal code, city</em>
+      </p>
+
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="calc-origin">
+          Origin (your address)
+        </label>
+        <input
+          id="calc-origin"
+          type="text"
+          className={styles.input}
+          placeholder="e.g. Keizersgracht 123, 1015CZ, Amsterdam"
+          value={origin}
+          onChange={e => setOrigin(e.target.value)}
+        />
+      </div>
+
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="calc-dest">
+          Destination (office address)
+        </label>
+        <input
+          id="calc-dest"
+          type="text"
+          className={styles.input}
+          placeholder="e.g. Stationsplein 1, 5211AP, Den Bosch"
+          value={destination}
+          onChange={e => setDestination(e.target.value)}
+        />
+      </div>
+
+      <button
+        type="button"
+        className="btn btn-outline"
+        onClick={handleCalculate}
+        disabled={!canCalculate}
+      >
+        {status === "loading" ? "Calculating..." : "Calculate Commute"}
+      </button>
+
+      {status === "success" && result && (
+        <div className={styles.results}>
+          <div className={styles.resultCardLayout}>
+            <div className={styles.resultCard}>
+              <strong>Car</strong>
+              {isRouteResult(result.car) ? (
+                <p>
+                  {result.car.durationMinutes} min &middot; {result.car.distanceKm} km
+                </p>
+              ) : (
+                <p className={styles.errorText}>{result.car.message}</p>
+              )}
+            </div>
+
+            <div className={styles.resultCard}>
+              <strong>Public Transport</strong>
+              {result.publicTransport && isRouteResult(result.publicTransport) ? (
+                <p>
+                  {result.publicTransport.durationMinutes} min &middot;{" "}
+                  {result.publicTransport.distanceKm} km
+                </p>
+              ) : (
+                <p className={styles.muted}>
+                  {result.publicTransport
+                    ? result.publicTransport.message
+                    : "Not available for this route"}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {result.car && isRouteResult(result.car) && (
+            <div className={styles.layout}>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={handleApply}
+              >
+                Apply to Commute ({result.car.durationMinutes} min)
+              </button>
+
+              <label className={styles.checkbox}>
+                <input
+                  type="checkbox"
+                  checked={rememberOrigin}
+                  onChange={e => setRememberOrigin(e.target.checked)}
+                />
+                Remember origin address
+              </label>
+            </div>
+          )}
+        </div>
+      )}
+
+      {status === "error" && (
+        <div className={styles.error}>
+          <p className={styles.errorText}>{errorMsg}</p>
+          {diagnostics && (
+            <details
+              className={styles.diagnostics}
+              open={showDiag}
+              onToggle={e => setShowDiag((e.target as HTMLDetailsElement).open)}
+            >
+              <summary>Diagnostics</summary>
+              <pre>{diagnostics}</pre>
+            </details>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/evaluator/CommuteCalculator.tsx
+++ b/src/pages/evaluator/CommuteCalculator.tsx
@@ -1,11 +1,10 @@
 import { useState } from "react"
 import { fetchCommute } from "../../infrastructure/hereApi"
 import type { CommuteResult, RouteResult, HereApiError } from "../../infrastructure/hereApi"
-import { loadHomeAddress, saveHomeAddress, removeHomeAddress } from "../../infrastructure/homeAddressStorage"
+import { loadHomeAddress } from "../../infrastructure/homeAddressStorage"
 import styles from "./CommuteCalculator.module.css"
 
 interface Props {
-  commuteOrigin?: string
   commuteDestination?: string
   onApply: (minutes: number) => void
 }
@@ -25,19 +24,16 @@ function formatDiagnostics(err: HereApiError): string {
 }
 
 export default function CommuteCalculator({
-  commuteOrigin = "",
   commuteDestination = "",
   onApply,
 }: Props) {
-  const savedOrigin = loadHomeAddress()
-  const [origin, setOrigin] = useState(commuteOrigin || savedOrigin || "")
+  const origin = loadHomeAddress() ?? ""
   const [destination, setDestination] = useState(commuteDestination || "")
   const [status, setStatus] = useState<Status>("idle")
   const [result, setResult] = useState<CommuteResult | null>(null)
   const [errorMsg, setErrorMsg] = useState("")
   const [diagnostics, setDiagnostics] = useState<string | null>(null)
   const [showDiag, setShowDiag] = useState(false)
-  const [rememberOrigin, setRememberOrigin] = useState(!!savedOrigin)
 
   async function handleCalculate() {
     if (!origin.trim() || !destination.trim()) return
@@ -68,11 +64,6 @@ export default function CommuteCalculator({
   function handleApply() {
     if (!result || "category" in result.car) return
     onApply(result.car.durationMinutes)
-    if (rememberOrigin) {
-      saveHomeAddress(origin)
-    } else {
-      removeHomeAddress()
-    }
   }
 
   const canCalculate = status !== "loading" && origin.trim() && destination.trim()
@@ -92,10 +83,15 @@ export default function CommuteCalculator({
           id="calc-origin"
           type="text"
           className={styles.input}
-          placeholder="e.g. Keizersgracht 123, 1015CZ, Amsterdam"
           value={origin}
-          onChange={e => setOrigin(e.target.value)}
+          readOnly
+          placeholder={origin ? "" : "Set your home address in My Preferences"}
         />
+        {!origin && (
+          <p className={styles.hint}>
+            Set your home address in the My Preferences tab above.
+          </p>
+        )}
       </div>
 
       <div className={styles.field}>
@@ -161,15 +157,6 @@ export default function CommuteCalculator({
               >
                 Apply to Commute ({result.car.durationMinutes} min)
               </button>
-
-              <label className={styles.checkbox}>
-                <input
-                  type="checkbox"
-                  checked={rememberOrigin}
-                  onChange={e => setRememberOrigin(e.target.checked)}
-                />
-                Remember origin address
-              </label>
             </div>
           )}
         </div>

--- a/src/pages/evaluator/EvaluatorForm.tsx
+++ b/src/pages/evaluator/EvaluatorForm.tsx
@@ -217,7 +217,6 @@ export default function EvaluatorForm({ initialInput, onEvaluate, onReset }: Pro
       </div>
 
       <CommuteCalculator
-        commuteOrigin={form.commuteOrigin}
         commuteDestination={form.commuteDestination}
         onApply={(minutes) => handleChange('commuteMinutes', minutes)}
       />

--- a/src/pages/evaluator/EvaluatorForm.tsx
+++ b/src/pages/evaluator/EvaluatorForm.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import type { OpportunityInput } from '../../domain/evaluator/types'
+import CommuteCalculator from './CommuteCalculator'
 import styles from './EvaluatorForm.module.css'
 
 interface Props {
@@ -214,6 +215,12 @@ export default function EvaluatorForm({ initialInput, onEvaluate, onReset }: Pro
           rows={3}
         />
       </div>
+
+      <CommuteCalculator
+        commuteOrigin={form.commuteOrigin}
+        commuteDestination={form.commuteDestination}
+        onApply={(minutes) => handleChange('commuteMinutes', minutes)}
+      />
 
       <div className={styles.actions}>
         <button type="submit" className="btn btn-primary">

--- a/src/pages/evaluator/EvaluatorForm.tsx
+++ b/src/pages/evaluator/EvaluatorForm.tsx
@@ -116,7 +116,6 @@ export default function EvaluatorForm({ initialInput, onEvaluate, onReset }: Pro
             className={styles.input}
             min={0}
             max={300}
-            step={5}
             value={form.commuteMinutes}
             onChange={e => handleChange('commuteMinutes', Number(e.target.value))}
           />

--- a/src/pages/evaluator/PreferencesPanel.tsx
+++ b/src/pages/evaluator/PreferencesPanel.tsx
@@ -1,6 +1,8 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import type { ProfilePreferences } from '../../domain/evaluator/types'
 import { DEFAULT_PREFERENCES } from '../../domain/evaluator/defaultPreferences'
+import { loadFromStorage, saveToStorage } from '../../infrastructure/storage'
+import { STORAGE_KEYS } from '../../infrastructure/storageKeys'
 import styles from './PreferencesPanel.module.css'
 
 interface Props {
@@ -11,6 +13,26 @@ interface Props {
 export default function PreferencesPanel({ prefs, onChange }: Props) {
   const [domainInput, setDomainInput] = useState('')
   const [techInput, setTechInput] = useState('')
+  const [hereKey, setHereKey] = useState(() => loadFromStorage(STORAGE_KEYS.hereApiKey, ''))
+  const [hereKeySaved, setHereKeySaved] = useState(false)
+
+  useEffect(() => {
+    if (hereKeySaved) {
+      const timer = setTimeout(() => setHereKeySaved(false), 2000)
+      return () => clearTimeout(timer)
+    }
+  }, [hereKeySaved])
+
+  function handleHereKeySave() {
+    saveToStorage(STORAGE_KEYS.hereApiKey, hereKey)
+    setHereKeySaved(true)
+  }
+
+  function handleHereKeyClear() {
+    setHereKey('')
+    saveToStorage(STORAGE_KEYS.hereApiKey, '')
+    setHereKeySaved(true)
+  }
 
   function update<K extends keyof ProfilePreferences>(key: K, value: ProfilePreferences[K]) {
     onChange({ ...prefs, [key]: value })
@@ -222,6 +244,39 @@ export default function PreferencesPanel({ prefs, onChange }: Props) {
             ))}
           </div>
         </div>
+      </div>
+
+      {/* HERE API key */}
+      <div className={styles.group}>
+        <h3 className={styles.groupTitle}>Commute Calculator API Key</h3>
+        <p className={styles.desc}>
+          The commute calculator uses the HERE Routing API. Provide a key to enable
+          address-based commute calculation.{" "}
+          <a href="https://platform.here.com/" target="_blank" rel="noopener noreferrer">
+            Get a free key at platform.here.com
+          </a>
+          . Select the <strong>Geocoding & Search API v7</strong> and{" "}
+          <strong>Routing API v8</strong> products.
+        </p>
+        <div className={styles.addRow}>
+          <input
+            type="text"
+            className={styles.input}
+            placeholder="Paste your HERE API key..."
+            value={hereKey}
+            onChange={e => setHereKey(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && (e.preventDefault(), handleHereKeySave())}
+          />
+          <button type="button" className="btn btn-outline" onClick={handleHereKeySave}>
+            Save
+          </button>
+          {hereKey && (
+            <button type="button" className="btn btn-outline" onClick={handleHereKeyClear}>
+              Clear
+            </button>
+          )}
+        </div>
+        {hereKeySaved && <span className={styles.saved} style={{ marginTop: '0.3rem', display: 'inline-block' }}>✓ Saved</span>}
       </div>
 
       <div className={styles.footer}>

--- a/src/pages/evaluator/PreferencesPanel.tsx
+++ b/src/pages/evaluator/PreferencesPanel.tsx
@@ -260,7 +260,7 @@ export default function PreferencesPanel({ prefs, onChange }: Props) {
         </p>
         <div className={styles.addRow}>
           <input
-            type="text"
+            type="password"
             className={styles.input}
             placeholder="Paste your HERE API key..."
             value={hereKey}

--- a/src/pages/evaluator/PreferencesPanel.tsx
+++ b/src/pages/evaluator/PreferencesPanel.tsx
@@ -3,6 +3,7 @@ import type { ProfilePreferences } from '../../domain/evaluator/types'
 import { DEFAULT_PREFERENCES } from '../../domain/evaluator/defaultPreferences'
 import { loadFromStorage, saveToStorage } from '../../infrastructure/storage'
 import { STORAGE_KEYS } from '../../infrastructure/storageKeys'
+import { loadHomeAddress, saveHomeAddress, removeHomeAddress } from '../../infrastructure/homeAddressStorage'
 import styles from './PreferencesPanel.module.css'
 
 interface Props {
@@ -15,6 +16,8 @@ export default function PreferencesPanel({ prefs, onChange }: Props) {
   const [techInput, setTechInput] = useState('')
   const [hereKey, setHereKey] = useState(() => loadFromStorage(STORAGE_KEYS.hereApiKey, ''))
   const [hereKeySaved, setHereKeySaved] = useState(false)
+  const [homeAddress, setHomeAddress] = useState(() => loadHomeAddress() ?? '')
+  const [homeAddressSaved, setHomeAddressSaved] = useState(false)
 
   useEffect(() => {
     if (hereKeySaved) {
@@ -22,6 +25,13 @@ export default function PreferencesPanel({ prefs, onChange }: Props) {
       return () => clearTimeout(timer)
     }
   }, [hereKeySaved])
+
+  useEffect(() => {
+    if (homeAddressSaved) {
+      const timer = setTimeout(() => setHomeAddressSaved(false), 2000)
+      return () => clearTimeout(timer)
+    }
+  }, [homeAddressSaved])
 
   function handleHereKeySave() {
     saveToStorage(STORAGE_KEYS.hereApiKey, hereKey)
@@ -32,6 +42,17 @@ export default function PreferencesPanel({ prefs, onChange }: Props) {
     setHereKey('')
     saveToStorage(STORAGE_KEYS.hereApiKey, '')
     setHereKeySaved(true)
+  }
+
+  function handleHomeAddressSave() {
+    saveHomeAddress(homeAddress)
+    setHomeAddressSaved(true)
+  }
+
+  function handleHomeAddressClear() {
+    setHomeAddress('')
+    removeHomeAddress()
+    setHomeAddressSaved(true)
   }
 
   function update<K extends keyof ProfilePreferences>(key: K, value: ProfilePreferences[K]) {
@@ -139,7 +160,33 @@ export default function PreferencesPanel({ prefs, onChange }: Props) {
         {/* Travel */}
         <div className={styles.group}>
           <h3 className={styles.groupTitle}>Travel & Location</h3>
-          <div className={styles.row}>
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="pref-home-address">Home Address</label>
+            <p className={styles.desc}>
+              Used as the default origin in the commute calculator on the Evaluate tab.
+            </p>
+            <div className={styles.addRow}>
+              <input
+                id="pref-home-address"
+                type="text"
+                className={styles.input}
+                placeholder="e.g. Keizersgracht 123, 1015CZ, Amsterdam"
+                value={homeAddress}
+                onChange={e => setHomeAddress(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && (e.preventDefault(), handleHomeAddressSave())}
+              />
+              <button type="button" className="btn btn-outline" onClick={handleHomeAddressSave}>
+                Save
+              </button>
+              {homeAddress && (
+                <button type="button" className="btn btn-outline" onClick={handleHomeAddressClear}>
+                  Clear
+                </button>
+              )}
+            </div>
+            {homeAddressSaved && <span className={styles.saved} style={{ marginTop: '0.3rem', display: 'inline-block' }}>✓ Saved</span>}
+          </div>
+          <div className={styles.row} style={{ marginTop: '1rem' }}>
             <div className={styles.field}>
               <label className={styles.label} htmlFor="pref-commute">Max Commute (min)</label>
               <input

--- a/src/pages/evaluator/__tests__/CommuteCalculator.test.tsx
+++ b/src/pages/evaluator/__tests__/CommuteCalculator.test.tsx
@@ -1,0 +1,171 @@
+import { it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import CommuteCalculator from "../CommuteCalculator"
+
+const mockFetchCommute = vi.fn()
+
+vi.mock("../../../infrastructure/hereApi", () => ({
+  fetchCommute: (...args: unknown[]) => mockFetchCommute(...args),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function renderCalculator(props?: Partial<React.ComponentProps<typeof CommuteCalculator>>) {
+  const onApply = vi.fn()
+  const utils = render(
+    <CommuteCalculator
+      commuteOrigin=""
+      commuteDestination=""
+      onApply={onApply}
+      {...props}
+    />,
+  )
+  return { ...utils, onApply }
+}
+
+it("renders inputs and calculate button in idle state", () => {
+  renderCalculator()
+
+  expect(screen.getByLabelText(/origin/i)).toBeInTheDocument()
+  expect(screen.getByLabelText(/destination/i)).toBeInTheDocument()
+  expect(screen.getByRole("button", { name: /calculate commute/i })).toBeInTheDocument()
+})
+
+it("disables calculate button when inputs are empty", () => {
+  renderCalculator()
+
+  const btn = screen.getByRole("button", { name: /calculate commute/i })
+  expect(btn).toBeDisabled()
+})
+
+it("enables calculate button when both inputs are filled", async () => {
+  renderCalculator()
+
+  const user = userEvent.setup()
+  await user.type(screen.getByLabelText(/origin/i), "Amsterdam")
+  await user.type(screen.getByLabelText(/destination/i), "Den Bosch")
+
+  const btn = screen.getByRole("button", { name: /calculate commute/i })
+  expect(btn).not.toBeDisabled()
+})
+
+it("shows loading state while calculating", async () => {
+  mockFetchCommute.mockImplementation(
+    () =>
+      new Promise(() => {
+        /* never resolves */
+      }),
+  )
+
+  renderCalculator()
+
+  const user = userEvent.setup()
+  await user.type(screen.getByLabelText(/origin/i), "O")
+  await user.type(screen.getByLabelText(/destination/i), "D")
+  await user.click(screen.getByRole("button", { name: /calculate commute/i }))
+
+  expect(screen.getByRole("button", { name: /calculating/i })).toBeDisabled()
+})
+
+it("displays car and PT results on success", async () => {
+  mockFetchCommute.mockResolvedValue({
+    car: { durationMinutes: 35, distanceKm: 42.5 },
+    publicTransport: { durationMinutes: 55, distanceKm: 45 },
+  })
+
+  renderCalculator()
+
+  const user = userEvent.setup()
+  await user.type(screen.getByLabelText(/origin/i), "O")
+  await user.type(screen.getByLabelText(/destination/i), "D")
+  await user.click(screen.getByRole("button", { name: /calculate commute/i }))
+
+  expect(await screen.findByText(/^35 min · 42\.5 km$/)).toBeInTheDocument()
+  expect(screen.getByText(/^55 min · 45 km$/)).toBeInTheDocument()
+  expect(screen.getByRole("button", { name: /apply to commute/i })).toBeInTheDocument()
+})
+
+it("calls onApply with correct minutes when Apply is clicked", async () => {
+  mockFetchCommute.mockResolvedValue({
+    car: { durationMinutes: 35, distanceKm: 42.5 },
+    publicTransport: null,
+  })
+
+  const { onApply } = renderCalculator()
+
+  const user = userEvent.setup()
+  await user.type(screen.getByLabelText(/origin/i), "O")
+  await user.type(screen.getByLabelText(/destination/i), "D")
+  await user.click(screen.getByRole("button", { name: /calculate commute/i }))
+
+  const applyBtn = await screen.findByRole("button", { name: /apply to commute/i })
+  await user.click(applyBtn)
+
+  expect(onApply).toHaveBeenCalledWith(35)
+})
+
+it("shows friendly error on API failure", async () => {
+  mockFetchCommute.mockResolvedValue({
+    car: {
+      category: "invalid_address",
+      message: "We could not find this address. Please add postal code and house number.",
+    },
+    publicTransport: null,
+  })
+
+  renderCalculator()
+
+  const user = userEvent.setup()
+  await user.type(screen.getByLabelText(/origin/i), "O")
+  await user.type(screen.getByLabelText(/destination/i), "D")
+  await user.click(screen.getByRole("button", { name: /calculate commute/i }))
+
+  expect(
+    await screen.findByText(/could not find this address/i),
+  ).toBeInTheDocument()
+})
+
+it("shows hidden diagnostics on API error", async () => {
+  mockFetchCommute.mockResolvedValue({
+    car: {
+      category: "rate_limited",
+      message: "Too many requests",
+      httpStatus: 429,
+      correlationId: "abc-123",
+    },
+    publicTransport: null,
+  })
+
+  renderCalculator()
+
+  const user = userEvent.setup()
+  await user.type(screen.getByLabelText(/origin/i), "O")
+  await user.type(screen.getByLabelText(/destination/i), "D")
+  await user.click(screen.getByRole("button", { name: /calculate commute/i }))
+
+  const diag = await screen.findByText(/diagnostics/i)
+  expect(diag).toBeInTheDocument()
+
+  await user.click(diag)
+  expect(screen.getByText(/rate_limited/i)).toBeInTheDocument()
+  expect(screen.getByText(/429/i)).toBeInTheDocument()
+})
+
+it("shows PT not available when PT is null", async () => {
+  mockFetchCommute.mockResolvedValue({
+    car: { durationMinutes: 20, distanceKm: 15 },
+    publicTransport: null,
+  })
+
+  renderCalculator()
+
+  const user = userEvent.setup()
+  await user.type(screen.getByLabelText(/origin/i), "O")
+  await user.type(screen.getByLabelText(/destination/i), "D")
+  await user.click(screen.getByRole("button", { name: /calculate commute/i }))
+
+  expect(await screen.findByText(/not available for this route/i)).toBeInTheDocument()
+})

--- a/src/pages/evaluator/__tests__/CommuteCalculator.test.tsx
+++ b/src/pages/evaluator/__tests__/CommuteCalculator.test.tsx
@@ -4,9 +4,17 @@ import userEvent from "@testing-library/user-event"
 import CommuteCalculator from "../CommuteCalculator"
 
 const mockFetchCommute = vi.fn()
+const mockSaveHomeAddress = vi.fn()
+const mockRemoveHomeAddress = vi.fn()
 
 vi.mock("../../../infrastructure/hereApi", () => ({
   fetchCommute: (...args: unknown[]) => mockFetchCommute(...args),
+}))
+
+vi.mock("../../../infrastructure/homeAddressStorage", () => ({
+  loadHomeAddress: () => undefined,
+  saveHomeAddress: (...args: unknown[]) => mockSaveHomeAddress(...args),
+  removeHomeAddress: (...args: unknown[]) => mockRemoveHomeAddress(...args),
 }))
 
 beforeEach(() => {
@@ -168,4 +176,70 @@ it("shows PT not available when PT is null", async () => {
   await user.click(screen.getByRole("button", { name: /calculate commute/i }))
 
   expect(await screen.findByText(/not available for this route/i)).toBeInTheDocument()
+})
+
+it("shows PT error message when PT returns HereApiError but car succeeds", async () => {
+  mockFetchCommute.mockResolvedValue({
+    car: { durationMinutes: 20, distanceKm: 15 },
+    publicTransport: {
+      category: "no_route",
+      message: "Public transport routing is not available for this route or API plan.",
+    },
+  })
+
+  renderCalculator()
+
+  const user = userEvent.setup()
+  await user.type(screen.getByLabelText(/origin/i), "O")
+  await user.type(screen.getByLabelText(/destination/i), "D")
+  await user.click(screen.getByRole("button", { name: /calculate commute/i }))
+
+  expect(await screen.findByText(/^20 min · 15 km$/)).toBeInTheDocument()
+  expect(
+    screen.getByText(/public transport routing is not available/i),
+  ).toBeInTheDocument()
+  expect(screen.getByRole("button", { name: /apply to commute/i })).toBeInTheDocument()
+})
+
+it("saves origin address when Remember origin is checked and Apply is clicked", async () => {
+  mockFetchCommute.mockResolvedValue({
+    car: { durationMinutes: 35, distanceKm: 42.5 },
+    publicTransport: null,
+  })
+
+  renderCalculator()
+
+  const user = userEvent.setup()
+  await user.type(screen.getByLabelText(/origin/i), "Keizersgracht 123, Amsterdam")
+  await user.type(screen.getByLabelText(/destination/i), "D")
+  await user.click(screen.getByRole("button", { name: /calculate commute/i }))
+
+  const rememberCb = await screen.findByLabelText(/remember origin/i)
+  await user.click(rememberCb)
+
+  const applyBtn = await screen.findByRole("button", { name: /apply to commute/i })
+  await user.click(applyBtn)
+
+  expect(mockSaveHomeAddress).toHaveBeenCalledWith("Keizersgracht 123, Amsterdam")
+  expect(mockRemoveHomeAddress).not.toHaveBeenCalled()
+})
+
+it("removes saved origin when Remember origin is unchecked and Apply is clicked", async () => {
+  mockFetchCommute.mockResolvedValue({
+    car: { durationMinutes: 35, distanceKm: 42.5 },
+    publicTransport: null,
+  })
+
+  renderCalculator()
+
+  const user = userEvent.setup()
+  await user.type(screen.getByLabelText(/origin/i), "Keizersgracht 123, Amsterdam")
+  await user.type(screen.getByLabelText(/destination/i), "D")
+  await user.click(screen.getByRole("button", { name: /calculate commute/i }))
+
+  const applyBtn = await screen.findByRole("button", { name: /apply to commute/i })
+  await user.click(applyBtn)
+
+  expect(mockRemoveHomeAddress).toHaveBeenCalled()
+  expect(mockSaveHomeAddress).not.toHaveBeenCalled()
 })

--- a/src/pages/evaluator/__tests__/CommuteCalculator.test.tsx
+++ b/src/pages/evaluator/__tests__/CommuteCalculator.test.tsx
@@ -4,28 +4,25 @@ import userEvent from "@testing-library/user-event"
 import CommuteCalculator from "../CommuteCalculator"
 
 const mockFetchCommute = vi.fn()
-const mockSaveHomeAddress = vi.fn()
-const mockRemoveHomeAddress = vi.fn()
+const mockLoadHomeAddress = vi.fn()
 
 vi.mock("../../../infrastructure/hereApi", () => ({
   fetchCommute: (...args: unknown[]) => mockFetchCommute(...args),
 }))
 
 vi.mock("../../../infrastructure/homeAddressStorage", () => ({
-  loadHomeAddress: () => undefined,
-  saveHomeAddress: (...args: unknown[]) => mockSaveHomeAddress(...args),
-  removeHomeAddress: (...args: unknown[]) => mockRemoveHomeAddress(...args),
+  loadHomeAddress: (...args: unknown[]) => mockLoadHomeAddress(...args),
 }))
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockLoadHomeAddress.mockReturnValue(undefined)
 })
 
 function renderCalculator(props?: Partial<React.ComponentProps<typeof CommuteCalculator>>) {
   const onApply = vi.fn()
   const utils = render(
     <CommuteCalculator
-      commuteOrigin=""
       commuteDestination=""
       onApply={onApply}
       {...props}
@@ -42,25 +39,51 @@ it("renders inputs and calculate button in idle state", () => {
   expect(screen.getByRole("button", { name: /calculate commute/i })).toBeInTheDocument()
 })
 
-it("disables calculate button when inputs are empty", () => {
+it("disables calculate button when destination is empty and no origin saved", () => {
   renderCalculator()
 
   const btn = screen.getByRole("button", { name: /calculate commute/i })
   expect(btn).toBeDisabled()
 })
 
-it("enables calculate button when both inputs are filled", async () => {
+it("disables calculate button when destination is empty even with saved origin", () => {
+  mockLoadHomeAddress.mockReturnValue("Amsterdam")
+  renderCalculator()
+
+  const btn = screen.getByRole("button", { name: /calculate commute/i })
+  expect(btn).toBeDisabled()
+})
+
+it("enables calculate button when origin is saved and destination is filled", async () => {
+  mockLoadHomeAddress.mockReturnValue("Amsterdam")
   renderCalculator()
 
   const user = userEvent.setup()
-  await user.type(screen.getByLabelText(/origin/i), "Amsterdam")
   await user.type(screen.getByLabelText(/destination/i), "Den Bosch")
 
   const btn = screen.getByRole("button", { name: /calculate commute/i })
   expect(btn).not.toBeDisabled()
 })
 
+it("shows hint when no origin is saved", () => {
+  renderCalculator()
+
+  expect(
+    screen.getByText(/set your home address in the my preferences tab/i),
+  ).toBeInTheDocument()
+})
+
+it("does not show hint when origin is saved", () => {
+  mockLoadHomeAddress.mockReturnValue("Keizersgracht 123, Amsterdam")
+  renderCalculator()
+
+  expect(
+    screen.queryByText(/set your home address in the my preferences tab/i),
+  ).not.toBeInTheDocument()
+})
+
 it("shows loading state while calculating", async () => {
+  mockLoadHomeAddress.mockReturnValue("Amsterdam")
   mockFetchCommute.mockImplementation(
     () =>
       new Promise(() => {
@@ -71,7 +94,6 @@ it("shows loading state while calculating", async () => {
   renderCalculator()
 
   const user = userEvent.setup()
-  await user.type(screen.getByLabelText(/origin/i), "O")
   await user.type(screen.getByLabelText(/destination/i), "D")
   await user.click(screen.getByRole("button", { name: /calculate commute/i }))
 
@@ -79,6 +101,7 @@ it("shows loading state while calculating", async () => {
 })
 
 it("displays car and PT results on success", async () => {
+  mockLoadHomeAddress.mockReturnValue("Amsterdam")
   mockFetchCommute.mockResolvedValue({
     car: { durationMinutes: 35, distanceKm: 42.5 },
     publicTransport: { durationMinutes: 55, distanceKm: 45 },
@@ -87,7 +110,6 @@ it("displays car and PT results on success", async () => {
   renderCalculator()
 
   const user = userEvent.setup()
-  await user.type(screen.getByLabelText(/origin/i), "O")
   await user.type(screen.getByLabelText(/destination/i), "D")
   await user.click(screen.getByRole("button", { name: /calculate commute/i }))
 
@@ -97,6 +119,7 @@ it("displays car and PT results on success", async () => {
 })
 
 it("calls onApply with correct minutes when Apply is clicked", async () => {
+  mockLoadHomeAddress.mockReturnValue("Amsterdam")
   mockFetchCommute.mockResolvedValue({
     car: { durationMinutes: 35, distanceKm: 42.5 },
     publicTransport: null,
@@ -105,7 +128,6 @@ it("calls onApply with correct minutes when Apply is clicked", async () => {
   const { onApply } = renderCalculator()
 
   const user = userEvent.setup()
-  await user.type(screen.getByLabelText(/origin/i), "O")
   await user.type(screen.getByLabelText(/destination/i), "D")
   await user.click(screen.getByRole("button", { name: /calculate commute/i }))
 
@@ -116,6 +138,7 @@ it("calls onApply with correct minutes when Apply is clicked", async () => {
 })
 
 it("shows friendly error on API failure", async () => {
+  mockLoadHomeAddress.mockReturnValue("Amsterdam")
   mockFetchCommute.mockResolvedValue({
     car: {
       category: "invalid_address",
@@ -127,7 +150,6 @@ it("shows friendly error on API failure", async () => {
   renderCalculator()
 
   const user = userEvent.setup()
-  await user.type(screen.getByLabelText(/origin/i), "O")
   await user.type(screen.getByLabelText(/destination/i), "D")
   await user.click(screen.getByRole("button", { name: /calculate commute/i }))
 
@@ -137,6 +159,7 @@ it("shows friendly error on API failure", async () => {
 })
 
 it("shows hidden diagnostics on API error", async () => {
+  mockLoadHomeAddress.mockReturnValue("Amsterdam")
   mockFetchCommute.mockResolvedValue({
     car: {
       category: "rate_limited",
@@ -150,7 +173,6 @@ it("shows hidden diagnostics on API error", async () => {
   renderCalculator()
 
   const user = userEvent.setup()
-  await user.type(screen.getByLabelText(/origin/i), "O")
   await user.type(screen.getByLabelText(/destination/i), "D")
   await user.click(screen.getByRole("button", { name: /calculate commute/i }))
 
@@ -163,6 +185,7 @@ it("shows hidden diagnostics on API error", async () => {
 })
 
 it("shows PT not available when PT is null", async () => {
+  mockLoadHomeAddress.mockReturnValue("Amsterdam")
   mockFetchCommute.mockResolvedValue({
     car: { durationMinutes: 20, distanceKm: 15 },
     publicTransport: null,
@@ -171,7 +194,6 @@ it("shows PT not available when PT is null", async () => {
   renderCalculator()
 
   const user = userEvent.setup()
-  await user.type(screen.getByLabelText(/origin/i), "O")
   await user.type(screen.getByLabelText(/destination/i), "D")
   await user.click(screen.getByRole("button", { name: /calculate commute/i }))
 
@@ -179,6 +201,7 @@ it("shows PT not available when PT is null", async () => {
 })
 
 it("shows PT error message when PT returns HereApiError but car succeeds", async () => {
+  mockLoadHomeAddress.mockReturnValue("Amsterdam")
   mockFetchCommute.mockResolvedValue({
     car: { durationMinutes: 20, distanceKm: 15 },
     publicTransport: {
@@ -190,7 +213,6 @@ it("shows PT error message when PT returns HereApiError but car succeeds", async
   renderCalculator()
 
   const user = userEvent.setup()
-  await user.type(screen.getByLabelText(/origin/i), "O")
   await user.type(screen.getByLabelText(/destination/i), "D")
   await user.click(screen.getByRole("button", { name: /calculate commute/i }))
 
@@ -199,47 +221,4 @@ it("shows PT error message when PT returns HereApiError but car succeeds", async
     screen.getByText(/public transport routing is not available/i),
   ).toBeInTheDocument()
   expect(screen.getByRole("button", { name: /apply to commute/i })).toBeInTheDocument()
-})
-
-it("saves origin address when Remember origin is checked and Apply is clicked", async () => {
-  mockFetchCommute.mockResolvedValue({
-    car: { durationMinutes: 35, distanceKm: 42.5 },
-    publicTransport: null,
-  })
-
-  renderCalculator()
-
-  const user = userEvent.setup()
-  await user.type(screen.getByLabelText(/origin/i), "Keizersgracht 123, Amsterdam")
-  await user.type(screen.getByLabelText(/destination/i), "D")
-  await user.click(screen.getByRole("button", { name: /calculate commute/i }))
-
-  const rememberCb = await screen.findByLabelText(/remember origin/i)
-  await user.click(rememberCb)
-
-  const applyBtn = await screen.findByRole("button", { name: /apply to commute/i })
-  await user.click(applyBtn)
-
-  expect(mockSaveHomeAddress).toHaveBeenCalledWith("Keizersgracht 123, Amsterdam")
-  expect(mockRemoveHomeAddress).not.toHaveBeenCalled()
-})
-
-it("removes saved origin when Remember origin is unchecked and Apply is clicked", async () => {
-  mockFetchCommute.mockResolvedValue({
-    car: { durationMinutes: 35, distanceKm: 42.5 },
-    publicTransport: null,
-  })
-
-  renderCalculator()
-
-  const user = userEvent.setup()
-  await user.type(screen.getByLabelText(/origin/i), "Keizersgracht 123, Amsterdam")
-  await user.type(screen.getByLabelText(/destination/i), "D")
-  await user.click(screen.getByRole("button", { name: /calculate commute/i }))
-
-  const applyBtn = await screen.findByRole("button", { name: /apply to commute/i })
-  await user.click(applyBtn)
-
-  expect(mockRemoveHomeAddress).toHaveBeenCalled()
-  expect(mockSaveHomeAddress).not.toHaveBeenCalled()
 })

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 declare module '*.module.css' {
   const classes: { readonly [key: string]: string }
   export default classes


### PR DESCRIPTION
## Summary
- Manage home address in Preferences; origin is read-only on the Evaluate tab
- Fix commute scoring model: round-trip excess with 30 min/day free threshold
- Replace `as any` with proper types in hereApi test
- Enable cleanup workflow (weekly schedule, real deletion)
- Allow any non-negative commute minutes in Evaluate form (remove step=5 that rejected valid values like 43)

## Test plan
- [x] `vitest run src/pages/evaluator/__tests__/EvaluatorForm.test.tsx` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)