### PR TITLE
fix(ci): guard against ERESOLVE breaks from oversized dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,11 @@ updates:
         update-types:
           - patch
           - minor
+    ignore:
+      # typescript 7.x fails `npm ci` with ERESOLVE: @typescript-eslint/eslint-plugin's
+      # peer range is "typescript >=4.8.4 <6.1.0" and has no release supporting TS 7 yet.
+      # Remove this once @typescript-eslint/eslint-plugin declares support for TS 7.
+      # See PR #76 (CI run 29139014727) for the failure this prevents.
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Validates that package.json/package-lock.json still resolve cleanly before
+# they leave the machine. Catches ERESOLVE peer-dependency conflicts (e.g. a
+# dependency bump whose peers aren't satisfied) that would otherwise only be
+# found by CI's "Install dependencies" step.
+set -euo pipefail
+
+zero="0000000000000000000000000000000000000000"
+changed=false
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [ "$local_sha" = "$zero" ] && continue # deleting a remote branch
+
+  base="$remote_sha"
+  if [ "$remote_sha" = "$zero" ] || ! git cat-file -e "$remote_sha" 2>/dev/null; then
+    base=$(git merge-base "$local_sha" origin/main 2>/dev/null || true)
+  fi
+
+  if [ -z "$base" ] || git diff --name-only "$base" "$local_sha" -- | grep -qE '^package(-lock)?\.json$'; then
+    changed=true
+  fi
+done
+
+if [ "$changed" = true ]; then
+  echo "pre-push: package.json/package-lock.json changed, validating with 'npm ci'..."
+  if ! npm ci --no-audit --no-fund; then
+    echo ""
+    echo "pre-push: 'npm ci' failed — this is usually an ERESOLVE peer-dependency"
+    echo "conflict that would also fail CI. Fix it locally before pushing."
+    exit 1
+  fi
+  echo "pre-push: npm ci succeeded."
+fi

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.9.0",
   "type": "module",
   "scripts": {
+    "prepare": "git config core.hooksPath hooks || true",
     "dev": "vite",
     "build": "tsc && vite build && node scripts/copy-github-pages-spa-fallback.mjs",
     "validate:site-metadata": "node scripts/validate-site-metadata.mjs",


### PR DESCRIPTION
## Summary
- CI run [29139014727](https://github.com/pkuppens/pkuppens.github.io/actions/runs/29139014727/job/86508660340) (PR #76) failed `npm ci`: `typescript@7.0.2` conflicts with `@typescript-eslint/eslint-plugin`'s peer range (`>=4.8.4 <6.1.0`). No release of typescript-eslint supports TS 7 yet.
- Add `ignore` rule in `dependabot.yml` for typescript major-version bumps, so this class of PR stops being opened until typescript-eslint catches up.
- Add a `hooks/pre-push` guard (wired via `prepare` -> `git config core.hooksPath hooks`) that runs `npm ci` whenever `package.json`/`package-lock.json` change in the outgoing push, so ERESOLVE conflicts are caught locally before they reach CI.

## Test plan
- [x] Reproduced the ERESOLVE failure locally by checking out PR #76 and running `npm ci`
- [x] `npm run lint`, `npm run typecheck`, `npm test` pass on this branch
- [x] Verified the pre-push hook fires and runs `npm ci` (both via manual simulation and the real `git push`)
- [x] Watch this PR's CI run to confirm green