### PR TITLE
#79: Add per-browser weak-area tracking to AI-901

### DIFF
--- a/public/trainings/README.md
+++ b/public/trainings/README.md
@@ -141,6 +141,33 @@ Every question carries `q` (prompt), `why` (explanation shown after answering, H
 `mode: "practice"` (lessons) reveals feedback per question; `mode: "exam"` (mocks) grades all questions
 on submit and shows a scaled score (~/1000, pass 700) with a pass/fail verdict.
 
+### Weak-area tracking (optional, per-browser)
+
+[`shared/progress.js`](./shared/progress.js) is an optional companion to `quiz.js`: load it *before*
+`quiz.js` and pass a third argument to `Quiz.render` to record every graded attempt to localStorage
+(no accounts, no backend, per-browser only — see AI-901's `index.html`/`lessons/*.html` for the pattern):
+
+```html
+<script src="../../shared/progress.js"></script>
+<script src="../../shared/quiz.js"></script>
+<script src="../data/0002.js"></script>
+<script>Quiz.render('q-core', window.TRAINING_DATA['0002'], { courseId: 'ai-901', datasetId: '0002' });</script>
+```
+
+`courseId`/`datasetId` are only used to build a stable per-question id (`datasetId:tag:index`); omit the
+third argument (or don't load `progress.js`) and a page behaves exactly as before. `Progress` exposes:
+
+- `Progress.weakTags(courseId)` — per-tag rolling accuracy, weakest first, once a tag has ≥3 attempts.
+- `Progress.filterWeighted(questions, courseId, count)` — given a flat pool of questions, returns a
+  subset biased toward weak tags (falls back to a plain shuffle with no history).
+- `Progress.reset(courseId)` — clears recorded attempts for that course.
+
+AI-901's `index.html` renders a "Your progress" panel from `weakTags()` once data exists, linking to
+`lessons/weak-areas.html` — an adaptive practice page that pools every dataset in the course and calls
+`filterWeighted()` to build a session weighted toward the reader's weakest domains. Copy that page's
+pattern (merge all `data/*.js` files, tag questions with `_qid`, call `filterWeighted`) for any other
+course that wants the same feature.
+
 ## Wiring a course into the site
 
 The `/trainings` card grid is not generated from this folder — it is a hand-maintained array in

--- a/public/trainings/ai-901/index.html
+++ b/public/trainings/ai-901/index.html
@@ -15,6 +15,8 @@
   Shareable with colleagues — every page stands alone.
 </div>
 
+<div id="progress-panel"></div>
+
 <h2>Start here</h2>
 <div class="grid">
   <div class="card"><h3>Diagnostic</h3><p><a href="lessons/0001-orientation-and-diagnostic.html">Lesson 01 — Orientation &amp; Diagnostic</a><br><span class="small">See the exam shape, take a 15-question spread across both domains.</span></p></div>
@@ -45,4 +47,36 @@
   <div class="card"><h3>Mock 2</h3><p><a href="lessons/0007-mock-exam-2.html">30 fresh · interleaved</a></p></div>
   <div class="card"><h3>Mock 3</h3><p><a href="lessons/0008-mock-exam-3.html">30 fresh · readiness gate</a></p></div>
 </div>
+
+<script src="../shared/progress.js"></script>
+<script>
+(function () {
+  var tags = window.Progress.weakTags('ai-901');
+  if (!tags.length) return; // nothing recorded yet — keep the landing page uncluttered
+  var panel = document.getElementById('progress-panel');
+  var rows = tags.map(function (t) {
+    var pct = Math.round(t.accuracy * 100);
+    return '<div class="dom-row"><span class="dom-name">' + t.tag + '</span>' +
+      '<div class="meter sm"><span style="width:' + pct + '%;background:' +
+      (pct >= 70 ? 'var(--good)' : 'var(--bad)') + '"></span></div>' +
+      '<span class="dom-num">' + t.attempts + ' seen · ' + pct + '%</span></div>';
+  }).join('');
+  panel.innerHTML =
+    '<div class="callout key">' +
+      '<span class="label">Your progress</span>' +
+      '<div class="dom-breakdown">' + rows + '</div>' +
+      '<p class="small" style="margin-top:.6rem">' +
+        '<a href="lessons/weak-areas.html">Practice your weak areas →</a>' +
+        ' &nbsp;·&nbsp; <a href="#" id="reset-progress">Reset progress</a>' +
+      '</p>' +
+    '</div>';
+  document.getElementById('reset-progress').addEventListener('click', function (e) {
+    e.preventDefault();
+    if (confirm('Clear all recorded AI-901 progress on this browser?')) {
+      window.Progress.reset('ai-901');
+      location.reload();
+    }
+  });
+})();
+</script>
 

--- a/public/trainings/ai-901/lessons/0001-orientation-and-diagnostic.html
+++ b/public/trainings/ai-901/lessons/0001-orientation-and-diagnostic.html
@@ -41,6 +41,7 @@
   <a href="../reference/exam-blueprint.html">Exam Blueprint →</a>
 </div>
 
+<script src="../../shared/progress.js"></script>
 <script src="../../shared/quiz.js"></script>
 <script src="../data/0001.js"></script>
-<script>Quiz.render('q-diag', window.TRAINING_DATA['0001']);</script>
+<script>Quiz.render('q-diag', window.TRAINING_DATA['0001'], { courseId: 'ai-901', datasetId: '0001' });</script>

--- a/public/trainings/ai-901/lessons/0002-foundry-portal-and-sdk.html
+++ b/public/trainings/ai-901/lessons/0002-foundry-portal-and-sdk.html
@@ -92,6 +92,7 @@ print(response.output_text)</code></pre>
   <a href="./0003-foundry-agents.html">Lesson 03: Agents →</a>
 </div>
 
+<script src="../../shared/progress.js"></script>
 <script src="../../shared/quiz.js"></script>
 <script src="../data/0002.js"></script>
-<script>Quiz.render('q-foundry', window.TRAINING_DATA['0002']);</script>
+<script>Quiz.render('q-foundry', window.TRAINING_DATA['0002'], { courseId: 'ai-901', datasetId: '0002' });</script>

--- a/public/trainings/ai-901/lessons/0003-foundry-agents.html
+++ b/public/trainings/ai-901/lessons/0003-foundry-agents.html
@@ -96,6 +96,7 @@ r2 = openai.responses.create(conversation=conversation.id,
   <a href="./0004-content-understanding.html">Lesson 04: Content Understanding →</a>
 </div>
 
+<script src="../../shared/progress.js"></script>
 <script src="../../shared/quiz.js"></script>
 <script src="../data/0003.js"></script>
-<script>Quiz.render('q-agents', window.TRAINING_DATA['0003']);</script>
+<script>Quiz.render('q-agents', window.TRAINING_DATA['0003'], { courseId: 'ai-901', datasetId: '0003' });</script>

--- a/public/trainings/ai-901/lessons/0004-content-understanding.html
+++ b/public/trainings/ai-901/lessons/0004-content-understanding.html
@@ -71,6 +71,7 @@
   <a href="./0005-speech-vision-multimodal.html">Lesson 05: Speech, Vision &amp; Multimodal →</a>
 </div>
 
+<script src="../../shared/progress.js"></script>
 <script src="../../shared/quiz.js"></script>
 <script src="../data/0004.js"></script>
-<script>Quiz.render('q-cu', window.TRAINING_DATA['0004']);</script>
+<script>Quiz.render('q-cu', window.TRAINING_DATA['0004'], { courseId: 'ai-901', datasetId: '0004' });</script>

--- a/public/trainings/ai-901/lessons/0005-speech-vision-multimodal.html
+++ b/public/trainings/ai-901/lessons/0005-speech-vision-multimodal.html
@@ -64,6 +64,7 @@
   <a href="./0001-orientation-and-diagnostic.html">Diagnostic</a>
 </div>
 
+<script src="../../shared/progress.js"></script>
 <script src="../../shared/quiz.js"></script>
 <script src="../data/0005.js"></script>
-<script>Quiz.render('q-svm', window.TRAINING_DATA['0005']);</script>
+<script>Quiz.render('q-svm', window.TRAINING_DATA['0005'], { courseId: 'ai-901', datasetId: '0005' });</script>

--- a/public/trainings/ai-901/lessons/0006-mock-exam-1.html
+++ b/public/trainings/ai-901/lessons/0006-mock-exam-1.html
@@ -24,6 +24,7 @@
   <a href="./0007-mock-exam-2.html">Mock Exam 2 →</a>
 </div>
 
+<script src="../../shared/progress.js"></script>
 <script src="../../shared/quiz.js"></script>
 <script src="../data/0006.js"></script>
-<script>Quiz.render('mock1', window.TRAINING_DATA['0006']);</script>
+<script>Quiz.render('mock1', window.TRAINING_DATA['0006'], { courseId: 'ai-901', datasetId: '0006' });</script>

--- a/public/trainings/ai-901/lessons/0007-mock-exam-2.html
+++ b/public/trainings/ai-901/lessons/0007-mock-exam-2.html
@@ -24,6 +24,7 @@
   <a href="./0008-mock-exam-3.html">Mock Exam 3 →</a>
 </div>
 
+<script src="../../shared/progress.js"></script>
 <script src="../../shared/quiz.js"></script>
 <script src="../data/0007.js"></script>
-<script>Quiz.render('mock2', window.TRAINING_DATA['0007']);</script>
+<script>Quiz.render('mock2', window.TRAINING_DATA['0007'], { courseId: 'ai-901', datasetId: '0007' });</script>

--- a/public/trainings/ai-901/lessons/0008-mock-exam-3.html
+++ b/public/trainings/ai-901/lessons/0008-mock-exam-3.html
@@ -24,6 +24,7 @@
   <a href="../reference/exam-blueprint.html">Exam Blueprint →</a>
 </div>
 
+<script src="../../shared/progress.js"></script>
 <script src="../../shared/quiz.js"></script>
 <script src="../data/0008.js"></script>
-<script>Quiz.render('mock3', window.TRAINING_DATA['0008']);</script>
+<script>Quiz.render('mock3', window.TRAINING_DATA['0008'], { courseId: 'ai-901', datasetId: '0008' });</script>

--- a/public/trainings/ai-901/lessons/weak-areas.html
+++ b/public/trainings/ai-901/lessons/weak-areas.html
@@ -1,0 +1,63 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../shared/site-nav.js"></script>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="stylesheet" href="../../shared/trainings.css">
+<title>Practice Weak Areas — AI-901</title>
+
+<p class="eyebrow">AI-901 · Adaptive practice</p>
+<h1>Practice your weak areas</h1>
+<p class="subtitle">Pulled from every lesson and mock exam you've taken on this browser, weighted toward the domains where your recorded accuracy is lowest.</p>
+
+<div id="weak-summary"></div>
+
+<div class="quiz" id="weak-quiz"></div>
+
+<div class="lesson-nav no-print">
+  <a href="../index.html">← Course home</a>
+</div>
+
+<script src="../../shared/progress.js"></script>
+<script src="../../shared/quiz.js"></script>
+<script src="../data/0001.js"></script>
+<script src="../data/0002.js"></script>
+<script src="../data/0003.js"></script>
+<script src="../data/0004.js"></script>
+<script src="../data/0005.js"></script>
+<script src="../data/0006.js"></script>
+<script src="../data/0007.js"></script>
+<script src="../data/0008.js"></script>
+<script>
+(function () {
+  var COURSE = 'ai-901';
+  var PRACTICE_SIZE = 15;
+
+  // Build one flat pool from every dataset, tagging each question with a stable
+  // qid (datasetId:tag:indexInFile) so repeat attempts here and on the source
+  // lesson page dedupe to the same weak-area stat.
+  var pool = [];
+  Object.keys(window.TRAINING_DATA).sort().forEach(function (datasetId) {
+    var qs = window.TRAINING_DATA[datasetId].questions || [];
+    qs.forEach(function (q, i) {
+      var copy = Object.assign({}, q, { _qid: datasetId + ':' + (q.tag || '-') + ':' + i });
+      pool.push(copy);
+    });
+  });
+
+  var weak = window.Progress.weakTags(COURSE);
+  var summary = document.getElementById('weak-summary');
+  if (!weak.length) {
+    summary.innerHTML = '<div class="callout warn"><span class="label">Not enough data yet</span>' +
+      'Take a lesson quiz or mock exam first — this page needs a few graded attempts per domain ' +
+      'before it can tell which ones are weak. Showing a random mix for now.</div>';
+  } else {
+    var focus = weak.filter(function (w) { return w.accuracy < 0.85; }).map(function (w) { return w.tag; });
+    summary.innerHTML = '<div class="callout key"><span class="label">Focus</span>' +
+      (focus.length ? 'Weighted toward: <b>' + focus.join(', ') + '</b>' : 'All domains are ≥85% — this is a light review mix.') +
+      '</div>';
+  }
+
+  var selected = window.Progress.filterWeighted(pool, COURSE, PRACTICE_SIZE);
+  window.Quiz.render('weak-quiz', { passMark: 0.7, questions: selected }, { courseId: COURSE, datasetId: 'weak-areas' });
+})();
+</script>

--- a/public/trainings/shared/progress.js
+++ b/public/trainings/shared/progress.js
@@ -1,0 +1,129 @@
+/* ===========================================================================
+   Trainings — shared weak-area progress tracker (v1)
+   Optional companion to shared/quiz.js. Load it BEFORE quiz.js on any page
+   that should record attempts:
+
+     <script src="../shared/progress.js"></script>
+     <script src="../shared/quiz.js"></script>
+     <script src="../data/0002.js"></script>
+     <script>Quiz.render('q-core', window.TRAINING_DATA['0002'], { courseId: 'ai-901', datasetId: '0002' });</script>
+
+   quiz.js calls window.Progress.record(...) itself when a `meta.courseId` is
+   passed to Quiz.render — this file has no dependency on quiz.js and works
+   standalone. Everything lives in localStorage, per-browser, no accounts.
+   =========================================================================== */
+(function (global) {
+  var KEY = "trainings_progress_v1";
+  var MAX_ATTEMPTS = 500;
+  var MIN_SAMPLE = 3; // don't flag a tag as "weak" until it has this many attempts
+
+  function load() {
+    try {
+      var raw = localStorage.getItem(KEY);
+      if (!raw) return { version: 1, attempts: [] };
+      var data = JSON.parse(raw);
+      if (!data || !Array.isArray(data.attempts)) return { version: 1, attempts: [] };
+      return data;
+    } catch (e) {
+      return { version: 1, attempts: [] };
+    }
+  }
+
+  function save(data) {
+    try {
+      localStorage.setItem(KEY, JSON.stringify(data));
+    } catch (e) {
+      /* storage may be unavailable (private mode / quota) */
+    }
+  }
+
+  /** Record one graded attempt. Safe to call from quiz.js on every question reveal/submit. */
+  function record(courseId, qid, tag, correct) {
+    if (!courseId || !qid) return;
+    var data = load();
+    data.attempts.push({ course: courseId, qid: qid, tag: tag || "", correct: !!correct, ts: Date.now() });
+    if (data.attempts.length > MAX_ATTEMPTS) {
+      data.attempts = data.attempts.slice(data.attempts.length - MAX_ATTEMPTS);
+    }
+    save(data);
+  }
+
+  /** Per-tag rolling accuracy for a course, most-recent attempt per qid wins (so retries update, not double-count). */
+  function tagStats(courseId) {
+    var data = load();
+    var latestByQid = {};
+    data.attempts
+      .filter(function (a) { return a.course === courseId; })
+      .forEach(function (a) { latestByQid[a.qid] = a; }); // later entries overwrite earlier ones
+
+    var tags = {};
+    Object.keys(latestByQid).forEach(function (qid) {
+      var a = latestByQid[qid];
+      var t = a.tag || "—";
+      tags[t] = tags[t] || { correct: 0, attempts: 0 };
+      tags[t].attempts++;
+      if (a.correct) tags[t].correct++;
+    });
+    return tags;
+  }
+
+  /** Tags sorted weakest-first: { tag, accuracy (0-1), attempts }. Excludes tags below MIN_SAMPLE. */
+  function weakTags(courseId) {
+    var tags = tagStats(courseId);
+    return Object.keys(tags)
+      .map(function (t) {
+        var s = tags[t];
+        return { tag: t, accuracy: s.correct / s.attempts, attempts: s.attempts };
+      })
+      .filter(function (s) { return s.attempts >= MIN_SAMPLE; })
+      .sort(function (a, b) { return a.accuracy - b.accuracy; });
+  }
+
+  /**
+   * Given a flat pool of question objects (each with a `.tag`), return a shuffled
+   * subset of `count` questions biased toward weak tags. Falls back to a plain
+   * shuffle when there isn't enough attempt history yet to know what's weak.
+   */
+  function filterWeighted(questions, courseId, count) {
+    count = count || questions.length;
+    var weak = weakTags(courseId);
+    var weight = {};
+    weak.forEach(function (w) {
+      // Weakest tags get up to 3x sampling weight; solid tags (>=85%) get 1x.
+      weight[w.tag] = w.accuracy >= 0.85 ? 1 : 1 + (1 - w.accuracy) * 2;
+    });
+
+    var pool = [];
+    questions.forEach(function (q) {
+      var w = weight[q.tag || "—"] || 1;
+      var copies = Math.max(1, Math.round(w));
+      for (var i = 0; i < copies; i++) pool.push(q);
+    });
+
+    // Fisher-Yates shuffle, then dedupe back down to `count` distinct questions.
+    for (var i = pool.length - 1; i > 0; i--) {
+      var j = Math.floor(Math.random() * (i + 1));
+      var tmp = pool[i]; pool[i] = pool[j]; pool[j] = tmp;
+    }
+    var seen = new Set();
+    var out = [];
+    for (var k = 0; k < pool.length && out.length < count; k++) {
+      if (seen.has(pool[k])) continue;
+      seen.add(pool[k]);
+      out.push(pool[k]);
+    }
+    return out;
+  }
+
+  function reset(courseId) {
+    if (!courseId) {
+      save({ version: 1, attempts: [] });
+      return;
+    }
+    var data = load();
+    data.attempts = data.attempts.filter(function (a) { return a.course !== courseId; });
+    save(data);
+  }
+
+  global.Progress = { record: record, weakTags: weakTags, filterWeighted: filterWeighted, reset: reset };
+})(window);

--- a/public/trainings/shared/quiz.js
+++ b/public/trainings/shared/quiz.js
@@ -173,16 +173,25 @@
     }
 
     return { card, isAnswered, isCorrect, lockAndReveal, getSelection, type,
-             tag: item.tag || "", locked: false };
+             tag: item.tag || "", locked: false, qid: item._qid };
   }
 
   /* ---- Renderer --------------------------------------------------------- */
-  function render(elId, cfg) {
+  // `meta` is optional: { courseId, datasetId }. When present and window.Progress
+  // is loaded, each graded question is recorded for weak-area tracking — see
+  // shared/progress.js. Omit meta (or don't load progress.js) and nothing changes.
+  function render(elId, cfg, meta) {
     const root = document.getElementById(elId);
     if (!root) return;
     const mode = cfg.mode || "practice";
     const passPct = Math.round((cfg.passMark ?? 0.7) * 100);
     const questions = cfg.questions.map((it, i) => buildQuestion(it, i, mode));
+
+    function recordResult(q, idx) {
+      if (!window.Progress || !meta || !meta.courseId) return;
+      const qid = q.qid || ((meta.datasetId || "?") + ":" + (q.tag || "-") + ":" + idx);
+      window.Progress.record(meta.courseId, qid, q.tag || "", q.isCorrect());
+    }
 
     // Header
     const head = el("div", "quiz-head");
@@ -231,7 +240,7 @@
     function submitExam() {
       if (submitted) return;
       submitted = true;
-      questions.forEach(q => { q.locked = true; q.lockAndReveal(); });
+      questions.forEach((q, idx) => { q.locked = true; q.lockAndReveal(); recordResult(q, idx); });
       correct = questions.filter(q => q.isCorrect()).length;
       const pct = Math.round(correct / questions.length * 100);
       const scaled = Math.round(pct * 10); // rough /1000 estimate
@@ -257,7 +266,7 @@
     }
 
     // Wire up per-question interaction
-    questions.forEach(q => {
+    questions.forEach((q, idx) => {
       root.appendChild(q.card);
       if (mode === "practice") {
         // lock+reveal on first complete answer
@@ -265,6 +274,7 @@
           if (q.locked || !q.isAnswered()) return;
           q.locked = true;
           q.lockAndReveal();
+          recordResult(q, idx);
           tallyPractice();
           if (answered === questions.length) {
             const pct = Math.round(correct / questions.length * 100);


### PR DESCRIPTION
Closes #79

## Summary
- Adds `public/trainings/shared/progress.js`, an optional companion to the quiz engine: records each graded attempt to `localStorage` (per-browser, no accounts/backend), keyed by course + a stable `datasetId:tag:index` question id.
- Extends `quiz.js` with an optional third `meta` param (`{ courseId, datasetId }`) to `Quiz.render` — when present it calls `Progress.record(...)` on every question reveal/submit; omit it and behavior is unchanged (backward compatible with DP-900 and any other caller).
- Wires `progress.js` + `meta` into all 8 AI-901 lesson/mock-exam pages.
- Adds a "Your progress" panel + "Reset progress" control to `ai-901/index.html`, driven by `Progress.weakTags()`.
- Adds `ai-901/lessons/weak-areas.html` — pools every AI-901 dataset and calls `Progress.filterWeighted()` to build a 15-question practice set weighted toward the reader's weakest domains.
- Documents the pattern in `public/trainings/README.md` for reuse on other courses.

Scoped as Tier 1 of a two-tier plan; Tier 2 (an Azure Function backend for LLM-generated practice questions, optionally web-search-grounded) is intentionally out of scope here — it needs real cloud infra/secrets/cost controls and will be tracked as its own follow-up issue.

## Test plan
- [x] `npm test` — full suite (135 tests, 14 files) passes, including `src/trainings/__tests__/quizEngine.test.ts`
- [x] Manually verified in a browser (`npm run dev`):
  - [x] Answering a question on a lesson page records an attempt in `trainings_progress_v1`
  - [x] Seeding weak D1 / strong D2 history renders the correct per-domain accuracy panel on `ai-901/index.html`
  - [x] `weak-areas.html` shows a "Focus: D1, D2" summary and visibly over-samples the weaker domain (D1) in the generated 15-question set
  - [x] "Reset progress" clears `localStorage` and the panel disappears
  - [x] No console errors on any touched page

🤖 Generated with [Claude Code](https://claude.com/claude-code)