### PR TITLE
#91: Configure agent-skills docs and reconcile domain context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+## Agent skills
+
+### Issue tracker
+
+Issues live in this repo's GitHub Issues (`github.com/pkuppens/pkuppens.github.io`), via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default five canonical labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`), used as-is. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,52 +2,36 @@
 
 Vocabulary for architecture reviews and implementation. Use these terms consistently.
 
-## Core concepts
+For the architecture map (module layout, file paths, deployment) see [docs/arc42/architecture.md](docs/arc42/architecture.md).
+
+## Language
 
 **Profile**
-Pieter's professional identity: work preferences, experience timeline, and technology stack. Canonical data lives in `src/domain/profile/`. The Profile page and Opportunity Evaluator both read from this module.
+Pieter's professional identity: work preferences, experience timeline, and technology stack. The Profile page and Opportunity Evaluator both read from it.
 
 **Opportunity**
-A potential assignment described by the visitor (title, domain, rate, commute, hybrid days, duration, technologies). Represented as `OpportunityInput`.
+A potential assignment described by the visitor: title, domain, rate, commute, hybrid days, duration, technologies.
 
 **Evaluation**
 The scored result of comparing one Opportunity against Profile preferences: total score, per-criterion breakdown, fit level, and recommendation text.
 
 **Criterion**
-One weighted dimension of an Evaluation (domain fit, hourly rate, hours per week, commute, hybrid arrangement, contract duration, technology fit). Each criterion is a pure `evaluate` function in `criteria.ts`. Commute logic lives in `commuteScore.ts` and weights degradation by √(onsite days per week).
+One weighted dimension of an Evaluation (domain fit, hourly rate, hours per week, commute, hybrid arrangement, contract duration, technology fit). Commute weighting degrades by √(onsite days per week).
 
 **Evaluator session**
-Browser-local state for the evaluator tool: saved opportunity input, optionally adjusted preferences, and the last Evaluation result. Orchestrated by `evaluatorSession.ts` / `useEvaluatorSession`.
+Browser-local state for the evaluator tool: saved opportunity input, optionally adjusted preferences, and the last Evaluation result.
 
 **Score band**
-A labelled range for a 0–100 score (excellent / good / fair / poor) with shared thresholds for overall results and per-criterion bars. Defined in `scoreBands.ts`.
+A labelled range for a 0–100 score (excellent / good / fair / poor), with shared thresholds for overall results and per-criterion bars.
 
-## Persistence
+**Visitor preference override**
+A visitor's per-browser edit to scoring preferences in the evaluator UI. The versioned Profile in the repo is the default when no override is stored. See ADR 003.
+_Avoid_: user setting, custom preferences.
 
-**Storage keys**
-All `localStorage` access uses the `pkuppens_` prefix via `src/infrastructure/storage.ts`. Keys are listed in `storageKeys.ts` (evaluator input, evaluator preferences, theme, home address, HERE API key).
+**Commute Calculator**
+Tool within the evaluator that resolves a car/public-transport commute time from an origin and destination address, so visitors don't have to guess `commuteMinutes`. See ADR 005.
+_Avoid_: route planner, trip calculator.
 
-**Visitor preference overrides**
-Visitors may edit scoring preferences in the UI; those overrides are stored per browser. The versioned **Profile** in the repo remains the default when storage is empty. See ADR 003.
-
-**Post-deploy verification**
-Automated check that the live GitHub Pages site matches expectations after a deploy. May retry with backoff when the CDN has not caught up yet.
-
-## Commute calculator
-
-**HERE API client**
-`src/infrastructure/hereApi.ts` provides `geocodeAddress`, `fetchRoute`, and `fetchCommute` functions that call HERE Geocoding & Search API v7 and Routing API v8. The API key is resolved from localStorage (user-provided) or `VITE_HERE_API_KEY` (build-time fallback).
-
-**CommuteCalculator component**
-`src/pages/evaluator/CommuteCalculator.tsx` renders address inputs, a Calculate button, and result cards for car and public transport. It lives inline in `EvaluatorForm` below the commute minutes field. An "Apply" button fills `commuteMinutes` from the calculated car duration.
-
-**API Key**
-Users enter their key in the Preferences panel; it is stored in localStorage via `homeAddressStorage.ts` / `storageKeys.ts`. When no key is present the calculator shows a message prompting configuration rather than crashing. See ADR 004.
-
-**Origin persistence**
-The "Remember origin" checkbox allows optional localStorage persistence of the origin address.
-
-## Out of scope (parked)
-
-**LinkedIn experience mirror**
-`data/linkedin/` and `scripts/linkedin/` are a future export path. Experience content is maintained in the Profile module until XML export is automated.
+**LinkedIn mirror**
+A canonical local copy of a LinkedIn-style experience profile, stored per-person as `data/linkedin/<vanitySlug>.xml` and validated against a shared schema. Maintained through a dedicated editor UI (forms + live preview), with JSON/CSV exports derived from the same source — never by scraping linkedin.com. See #42 and #90.
+_Avoid_: LinkedIn scrape, profile importer.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Page-template/authoring conventions for course pages (head block, shared nav, qu
 - [ADR 002: Pure Functions for Scoring](docs/adr/002-pure-functions-scoring.md)
 - [ADR 003: localStorage Persistence](docs/adr/003-localstorage-persistence.md)
 - [ADR 004: Commit package-lock.json](docs/adr/004-commit-package-lock.md)
+- [ADR 005: HERE Routing API Integration](docs/adr/005-here-api-integration.md)
 
 ## Security and dependencies
 - **`package-lock.json` is committed** so `npm ci` in CI matches installs; see ADR 004.

--- a/docs/adr/005-here-api-integration.md
+++ b/docs/adr/005-here-api-integration.md
@@ -1,4 +1,4 @@
-# ADR 004: HERE Routing API Integration for Commute Calculator
+# ADR 005: HERE Routing API Integration for Commute Calculator
 
 ## Status
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,37 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (this repo):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 001-react-typescript-vite.md
+│   ├── 002-pure-functions-scoring.md
+│   └── ...
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-003 (localStorage persistence) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| --------------------------- | --------------------- | ----------------------------------------- |
+| `needs-triage`              | `needs-triage`        | Maintainer needs to evaluate this issue   |
+| `needs-info`                | `needs-info`          | Waiting on reporter for more information  |
+| `ready-for-agent`           | `ready-for-agent`     | Fully specified, ready for an AFK agent   |
+| `ready-for-human`           | `ready-for-human`     | Requires human implementation             |
+| `wontfix`                   | `wontfix`              | Will not be actioned                      |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/arc42/architecture.md
+++ b/docs/arc42/architecture.md
@@ -36,15 +36,24 @@ src/
 ├── components/layout/   – Header, Footer, Layout (shell)
 ├── pages/               – Route-level page components
 │   └── evaluator/       – Opportunity Evaluator UI + useEvaluatorSession
+│       └── CommuteCalculator.tsx – address inputs, HERE-backed car/PT results, "Apply" fills commuteMinutes
 ├── domain/profile/      – Canonical Profile data (CV + evaluator defaults)
 ├── domain/evaluator/    – Pure scoring logic (no React)
 │   ├── types.ts         – Domain types
-│   ├── criteria.ts      – Criterion definitions + evaluation functions
+│   ├── criteria.ts      – Criterion definitions + evaluation functions (commute weighting in commuteScore.ts)
 │   ├── scoring.ts       – Score aggregation engine
 │   ├── scoreBands.ts    – Shared score thresholds and presentation
 │   ├── evaluatorSession.ts – Load/save/evaluate session (no React)
 │   └── defaultPreferences.ts – Re-exports profile scoring preferences
-└── infrastructure/      – Storage, theme, storage key registry
+└── infrastructure/
+    ├── storage.ts       – localStorage abstraction, `pkuppens_` key prefix
+    ├── storageKeys.ts   – registry of all localStorage keys (evaluator input/preferences, theme, home address, HERE API key)
+    ├── homeAddressStorage.ts – optional origin-address persistence ("Remember origin")
+    └── hereApi.ts        – geocodeAddress / fetchRoute / fetchCommute via HERE Geocoding v7 + Routing v8; see ADR 005
+
+data/linkedin/<vanitySlug>.xml – canonical local LinkedIn-experience mirror, validated against scripts/linkedin/schema.xsd
+scripts/linkedin/          – validate.mjs, export-json.mjs, export-csv.mjs
+src/pages/ (planned, #90)  – dev-only editor route: forms + live preview for data/linkedin/<slug>.xml, reusing the scripts/linkedin parsing/serialization logic
 ```
 
 ## 6. Runtime View
@@ -66,6 +75,12 @@ src/
 ### Dependencies and supply chain
 - `package-lock.json` is committed so CI (`npm ci`) and local installs stay aligned; see [ADR 004: Commit package-lock](../adr/004-commit-package-lock.md).
 - Weekly **Dependabot** version updates and a scheduled **`npm audit`** workflow support dependency hygiene (see `.github/dependabot.yml` and `.github/workflows/security-audit.yml`).
+
+### HERE API key resolution
+Two-tier lookup: a user-entered key in the Preferences panel (stored in `localStorage`) takes priority over the build-time `VITE_HERE_API_KEY` fallback. With no key present, the Commute Calculator shows a configuration prompt instead of failing. See [ADR 005](../adr/005-here-api-integration.md).
+
+### Post-deploy verification
+After a GitHub Pages deploy, an automated check confirms the live site matches expectations, retrying with backoff if the CDN hasn't caught up yet.
 
 ### Testing Strategy
 - Unit tests: criteria, scoring, profile consistency, evaluator session, storage (Vitest)


### PR DESCRIPTION
Closes #91

## Summary
- Add `CLAUDE.md` `## Agent skills` block + `docs/agents/*.md` (issue tracker, triage labels, domain-doc layout) for the Matt Pocock engineering skills
- Rewrite `CONTEXT.md` as a pure glossary; move implementation details (file paths, component names) into `docs/arc42/architecture.md`
- Update the **LinkedIn mirror** glossary entry to match shipped state (#42) instead of describing it as a future export path; points to #90 for the remaining editor UI
- Renumber `docs/adr/004-here-api-integration.md` → `005-here-api-integration.md` (it collided with `004-commit-package-lock.md`) and link it from README and `architecture.md`, where it was previously unlinked from both

## Test plan
- [ ] Skim `CONTEXT.md` — confirm it reads as glossary-only, no stray implementation detail
- [ ] Confirm `docs/adr/004-commit-package-lock.md` and `005-here-api-integration.md` are both linked from README and `architecture.md`
- [ ] Docs-only change — no app code touched; `npm run typecheck && npm test && npm run build` not required but can be run as a sanity check

🤖 Generated with [Claude Code](https://claude.com/claude-code)