### PR TITLE
#97: Ship linkedin-editor in production with session-storage save/load

### DIFF
--- a/scripts/linkedin/README.md
+++ b/scripts/linkedin/README.md
@@ -25,27 +25,32 @@ Target committed data: **`data/linkedin/pieterkuppens.xml`** for [linkedin.com/i
 - `npm run linkedin:export:json -- --in data/linkedin/pieterkuppens.xml` — export derived JSON
 - `npm run linkedin:export:csv -- --in data/linkedin/pieterkuppens.xml` — export derived CSV
 
-## Local editor (dev-only)
+## Editor (unlinked, ships in production)
 
-`npm run dev`, then open **`/linkedin-editor`** (not linked from the site nav — it's a
-maintenance tool, not a public page). It renders a form for the Experience section defined by
-`schema.xsd` (top-level `experience` items and grouped `experienceGroup`/roles), with a
-LinkedIn-style read-only preview panel that updates as you type.
+Open **`/linkedin-editor`** — locally via `npm run dev`, or on the deployed site (it's not linked
+from the site nav — it's a maintenance tool, not a public page). It renders a form for the
+Experience section defined by `schema.xsd` (top-level `experience` items and grouped
+`experienceGroup`/roles), with a LinkedIn-style read-only preview panel that updates as you type.
 
-- **Load data/linkedin/&lt;slug&gt;.xml** — fetches the file from disk via a dev-server-only API
-  (`vite.config.ts`'s `linkedinEditorApi` plugin; it does not exist in the production build).
+- **Load data/linkedin/&lt;slug&gt;.xml** / **Save to data/linkedin/&lt;slug&gt;.xml** —
+  **dev-only**, only shown when running `npm run dev`. Reads/writes the file on disk via a
+  dev-server-only API (`vite.config.ts`'s `linkedinEditorApi` plugin; it does not exist in the
+  production build). This is a filesystem write on your own machine, not a deploy: you still
+  review, `npm run linkedin:validate`, and commit the result via git like any other local change.
+- **Load from browser session** / **Save to browser session** — works everywhere, including the
+  deployed production site. Persists the current XML in `sessionStorage`, keyed by slug, so edits
+  survive a page reload within the same browser tab/session. Nothing leaves the browser and
+  nothing is written to disk; refresh in a new tab/session and it's gone.
 - **Load from file…** — parses a locally chosen `.xml` file instead, for editing outside this repo's checkout.
 - **Download .xml** / **Copy .xml to clipboard** — exports the current form state as XML text; the
   usual path is to overwrite `data/linkedin/<slug>.xml` and review the diff yourself.
-- **Save to data/linkedin/&lt;slug&gt;.xml** — has the same dev-only API write the file directly.
-  This is a filesystem write on your own machine, not a deploy: you still review, `npm run
-  linkedin:validate`, and commit the result via git like any other local change.
 
-This remains a **manual/assisted workflow** — it does not scrape linkedin.com, and the "save"
-action never leaves your machine. After editing, re-run `npm run linkedin:validate -- --in
+This remains a **manual/assisted workflow** — it does not scrape linkedin.com, and no action here
+writes to the deployed site. After editing, re-run `npm run linkedin:validate -- --in
 data/linkedin/<slug>.xml` before committing.
 
 ## Related GitHub tracking
 
 - **[#42](https://github.com/pkuppens/pkuppens.github.io/issues/42)** — web/AI-assisted editor and `data/linkedin/<slug>` mirror workflow (data model, seed file, and CLI tooling scope)
 - **[#90](https://github.com/pkuppens/pkuppens.github.io/issues/90)** — the local editor UI itself (split from #42)
+- **[#97](https://github.com/pkuppens/pkuppens.github.io/issues/97)** — production access + browser-session load/save (follow-up to #90)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,8 +18,8 @@ function App() {
           <Route path="projects" element={<ProjectsPage />} />
           <Route path="trainings" element={<TrainingsPage />} />
           <Route path="evaluator" element={<EvaluatorPage />} />
-          {/* Dev-only, not linked from nav — see #90 / scripts/linkedin/README.md */}
-          {import.meta.env.DEV && <Route path="linkedin-editor" element={<LinkedInEditorPage />} />}
+          {/* Unlinked from nav — maintenance tool, see #90, #97 / scripts/linkedin/README.md */}
+          <Route path="linkedin-editor" element={<LinkedInEditorPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/pages/linkedin-editor/LinkedInEditorPage.tsx
+++ b/src/pages/linkedin-editor/LinkedInEditorPage.tsx
@@ -14,6 +14,8 @@ export default function LinkedInEditorPage() {
     loadFromXmlText,
     loadFromDevServer,
     saveToDevServer,
+    loadFromSession,
+    saveToSession,
     addExperience,
     addExperienceGroup,
     updateItem,
@@ -77,12 +79,17 @@ export default function LinkedInEditorPage() {
 
               <fieldset className={styles.toolbarGroup}>
                 <legend className={styles.toolbarGroupLabel}>Import</legend>
-                <button
-                  type="button"
-                  className={`btn btn-outline ${styles.toolbarSlugButton}`}
-                  onClick={loadFromDevServer}
-                >
-                  Load data/linkedin/{slug}.xml
+                {import.meta.env.DEV && (
+                  <button
+                    type="button"
+                    className={`btn btn-outline ${styles.toolbarSlugButton}`}
+                    onClick={loadFromDevServer}
+                  >
+                    Load data/linkedin/{slug}.xml
+                  </button>
+                )}
+                <button type="button" className="btn btn-outline" onClick={loadFromSession}>
+                  Load from browser session
                 </button>
                 <button type="button" className="btn btn-outline" onClick={() => fileInputRef.current?.click()}>
                   Load from file…
@@ -93,12 +100,17 @@ export default function LinkedInEditorPage() {
 
             <fieldset className={styles.toolbarGroup} disabled={model.items.length === 0}>
               <legend className={styles.toolbarGroupLabel}>Export</legend>
-              <button
-                type="button"
-                className={`btn btn-outline ${styles.toolbarSlugButton}`}
-                onClick={saveToDevServer}
-              >
-                Save to data/linkedin/{slug}.xml
+              {import.meta.env.DEV && (
+                <button
+                  type="button"
+                  className={`btn btn-outline ${styles.toolbarSlugButton}`}
+                  onClick={saveToDevServer}
+                >
+                  Save to data/linkedin/{slug}.xml
+                </button>
+              )}
+              <button type="button" className="btn btn-outline" onClick={saveToSession}>
+                Save to browser session
               </button>
               <button type="button" className="btn btn-outline" onClick={handleDownload}>
                 Download .xml

--- a/src/pages/linkedin-editor/useLinkedInEditor.ts
+++ b/src/pages/linkedin-editor/useLinkedInEditor.ts
@@ -14,6 +14,10 @@ import {
 
 const DEFAULT_SLUG = 'pieterkuppens'
 
+function sessionKey(slug: string): string {
+  return `linkedin-editor:${slug}`
+}
+
 function emptyModel(): ExperiencesDocumentModel {
   return { meta: null, items: [] }
 }
@@ -78,6 +82,24 @@ export function useLinkedInEditor() {
     }
   }, [model, slug])
 
+  const saveToSession = useCallback(() => {
+    try {
+      sessionStorage.setItem(sessionKey(slug), serializeExperiencesXml(model))
+      setStatus(`Saved to browser session storage (${slug}).`)
+    } catch (e) {
+      setStatus(`Save failed: ${String(e)}`)
+    }
+  }, [model, slug])
+
+  const loadFromSession = useCallback(() => {
+    const xml = sessionStorage.getItem(sessionKey(slug))
+    if (xml === null) {
+      setStatus(`No session data saved for "${slug}".`)
+      return
+    }
+    loadFromXmlText(xml)
+  }, [slug, loadFromXmlText])
+
   const addExperience = useCallback(() => {
     setModel((m) => ({ ...m, items: [...m.items, newExperience(nextId('experience', m))] }))
   }, [])
@@ -108,6 +130,8 @@ export function useLinkedInEditor() {
     loadFromXmlText,
     loadFromDevServer,
     saveToDevServer,
+    loadFromSession,
+    saveToSession,
     addExperience,
     addExperienceGroup,
     updateItem,


### PR DESCRIPTION
Closes #97

## Summary
- Removed the `import.meta.env.DEV` gate on the `linkedin-editor` route in `src/App.tsx` — it was stripping the route from the production build entirely, so `/linkedin-editor` rendered a blank page on GitHub Pages (no matching route, not a storage issue). Route stays unlinked from nav.
- Added `saveToSession` / `loadFromSession` to `useLinkedInEditor.ts`, backed by `sessionStorage` keyed by slug, so edits can be saved/reloaded in the browser without any server.
- Kept the "Load/Save to data/linkedin/&lt;slug&gt;.xml" buttons dev-only (`import.meta.env.DEV`) since they depend on the Vite-only filesystem middleware in `vite.config.ts`, which cannot exist on a static host.
- Updated `scripts/linkedin/README.md` to document the production session-storage workflow alongside the existing dev-only filesystem workflow.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (149 tests passing)
- [x] `npm run build` — confirms the route ships in the production bundle
- [ ] Manual: visit deployed `/linkedin-editor` and confirm it renders (was blank before this PR)